### PR TITLE
add time string formatting and validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"
@@ -27,3 +27,5 @@ tracing-subscriber = "0.3"
 ipnetwork = {version="0.18", default-features=false}
 serde={version="1.0", features=["derive"]}
 serde_json = "1.0"
+chrono = "0.4"
+anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::net::IpAddr;
 use bgpkit_parser::BgpkitParser;
 use itertools::Itertools;
+use anyhow::Result;
 
 pub fn parser_with_filters(
     file_path: &str,
@@ -11,10 +12,10 @@ pub fn parser_with_filters(
     peer_ip: &Vec<IpAddr>,
     peer_asn: &Option<u32>,
     elem_type: &Option<String>,
-    start_ts: &Option<f64>,
-    end_ts: &Option<f64>,
+    start_ts: &Option<String>,
+    end_ts: &Option<String>,
     as_path: &Option<String>,
-) -> BgpkitParser {
+) -> Result<BgpkitParser> {
 
     let mut parser = BgpkitParser::new(file_path).unwrap().disable_warnings();
 
@@ -49,5 +50,5 @@ pub fn parser_with_filters(
     if let Some(v) = end_ts {
         parser = parser.add_filter("end_ts", v.to_string().as_str()).unwrap();
     }
-    return parser
+    return Ok(parser)
 }


### PR DESCRIPTION
Supported time format:
- unix timestamp: `1640995200`
- rfc3999 without timezone (UTC): `2022-01-01T00:00:00`

Example query:
```
monocle search  --dry-run --start-ts 2022-01-01T00:00:00 --end-ts 2022-01-01T00:01:00
total of 108 files, 112932124 bytes to parse
```

Resolves #2 