### PR TITLE
Better time handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ serde={version="1.0", features=["derive"]}
 serde_json = "1.0"
 chrono = "0.4"
 anyhow = "1.0"
+tabled = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ cargo install monocle
 Subcommands:
 - `parse`: parse individual MRT files
 - `search`: search for matching messages from all available public MRT files
+- `time`: utility to convert time between unix timestamp and RFC3339 string
 
 Top-level help menu:
 ```text
@@ -36,6 +37,7 @@ SUBCOMMANDS:
     parse      Parse individual MRT files given a file path, local or remote
     scouter    Investigative toolbox
     search     Search BGP messages from all available public MRT files
+    time       Time conversion utilities
 ```
 
 ### `monocle parse`
@@ -95,6 +97,51 @@ OPTIONS:
     -t, --start-ts <START_TS>        Filter by start unix timestamp inclusive
     -T, --end-ts <END_TS>            Filter by end unix timestamp inclusive
     -V, --version                    Print version information
+```
+
+### `monocle time`
+
+```text
+➜  ~ monocle time --help              
+monocle-time 0.0.3
+Time conversion utilities
+
+USAGE:
+    monocle time [TIME]
+
+ARGS:
+    <TIME>    Time stamp or time string to convert
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+```
+
+Example runs:
+```text
+➜  monocle time
++------------+---------------------------+
+|    unix    |          rfc3339          |
++------------+---------------------------+
+| 1657850362 | 2022-07-15T01:59:22+00:00 |
++------------+---------------------------+
+
+➜  monocle time 0                               
++------+---------------------------+
+| unix |          rfc3339          |
++------+---------------------------+
+|  0   | 1970-01-01T00:00:00+00:00 |
++------+---------------------------+
+
+➜  monocle time 2022-01-01T00:00:00Z
++------------+---------------------------+
+|    unix    |          rfc3339          |
++------------+---------------------------+
+| 1640995200 | 2022-01-01T00:00:00+00:00 |
++------------+---------------------------+
+
+➜  monocle time 2022-01-01T00:00:00 
+Input time must be either Unix timestamp or time string compliant with RFC3339
 ```
 
 ## Built with ❤️ by BGPKIT Team

--- a/src/monocle.rs
+++ b/src/monocle.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-use monocle::parser_with_filters;
+use monocle::{parser_with_filters, time_to_table};
 use rayon::prelude::*;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -197,6 +197,12 @@ enum Commands {
         #[clap(flatten)]
         filters: SearchFilters,
     },
+    /// Time conversion utilities
+    Time {
+        /// Time stamp or time string to convert
+        #[clap()]
+        time: Option<String>,
+    },
     /// Investigative toolbox
     Scouter {
         /// Measure the power of your enemy
@@ -338,6 +344,16 @@ fn main() {
 
             /*
              */
+        }
+        Commands::Time { time} => {
+            match time_to_table(&time) {
+                Ok(t) => {
+                    println!("{}", t)
+                }
+                Err(e) => {
+                    eprintln!("{}", e)
+                }
+            }
         }
         Commands::Scouter {
             power: _


### PR DESCRIPTION
This PR adds a new subcommand `monocle time` to provide utility functions to convert between timestamps and RFC3339 time strings. 

This PR also adds proper RFC3339 string validation and enforcement. Time string without timezone are no longer accepted.

Resolves #5. Resolves #7.