### PR TITLE
allow search for multiple entries with `whois`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,10 +1069,12 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "papergrid"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608b6444acf7f5ea39e8bd06dd6037e34a4b5ddfb29ae840edad49ea798e9e79"
+checksum = "453cf71f2a37af495a1a124bf30d4d7469cfbea58e9f2479be9d222396a518a2"
 dependencies = [
+ "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -1507,20 +1515,23 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2407502760ccfd538f2fb1f843dd87b6daf1a17848d57bc5a25617e408ef4c7a"
+checksum = "e5b2f8c37d26d87d2252187b0a45ea3cbf42baca10377c7e7eaaa2800fa9bf97"
 dependencies = [
  "papergrid",
  "tabled_derive",
+ "unicode-width",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278ea3921cee8c5a69e0542998a089f7a14fa43c9c4e4f9951295da89bd0c943"
+checksum = "f9ee618502f497abf593e1c5c9577f34775b111480009ffccd7ad70d23fcaba8"
 dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde={version="1.0", features=["derive"]}
 serde_json = "1.0"
 chrono = "0.4"
 anyhow = "1.0"
-tabled = "0.7"
+tabled = "0.8"
 config = {version = "0.13.1", features = ["toml"]}
 dirs = "4"
 rusqlite = { version = "0.28.0", features = ["bundled"] }

--- a/README.md
+++ b/README.md
@@ -169,35 +169,64 @@ monocle-whois 0.0.4
 ASN and organization lookup utility
 
 USAGE:
-    monocle whois [OPTIONS] <QUERY>
+    monocle whois [OPTIONS] [QUERY]...
 
 ARGS:
-    <QUERY>    Search query, an ASN (e.g. "400644") or a name (e.g. "bgpkit")
+    <QUERY>...    Search query, an ASN (e.g. "400644") or a name (e.g. "bgpkit")
 
 OPTIONS:
     -a, --asn-only     Search by ASN only
     -h, --help         Print help information
+    -m, --markdown     Output to markdown table
     -n, --name-only    Search AS and Org name only
     -u, --update       Refresh local as2org database
     -V, --version      Print version information
+
 ```
 
 Example queries:
 ```text
 ➜  ~ monocle whois 400644
-+--------+------------+------------+--------------+-------------+----------+
-|  asn   |  as_name   |  org_name  |    org_id    | org_country | org_size |
-+--------+------------+------------+--------------+-------------+----------+
-| 400644 | BGPKIT-LLC | BGPKIT LLC | BL-1057-ARIN |     US      |    1     |
-+--------+------------+------------+--------------+-------------+----------+
+╭────────┬────────────┬────────────┬──────────────┬─────────────┬──────────╮
+│ asn    │ as_name    │ org_name   │ org_id       │ org_country │ org_size │
+├────────┼────────────┼────────────┼──────────────┼─────────────┼──────────┤
+│ 400644 │ BGPKIT-LLC │ BGPKIT LLC │ BL-1057-ARIN │ US          │ 1        │
+╰────────┴────────────┴────────────┴──────────────┴─────────────┴──────────╯
 
 ➜  ~ monocle whois bgpkit
-+--------+------------+------------+--------------+-------------+----------+
-|  asn   |  as_name   |  org_name  |    org_id    | org_country | org_size |
-+--------+------------+------------+--------------+-------------+----------+
-| 400644 | BGPKIT-LLC | BGPKIT LLC | BL-1057-ARIN |     US      |    1     |
-+--------+------------+------------+--------------+-------------+----------+
+╭────────┬────────────┬────────────┬──────────────┬─────────────┬──────────╮
+│ asn    │ as_name    │ org_name   │ org_id       │ org_country │ org_size │
+├────────┼────────────┼────────────┼──────────────┼─────────────┼──────────┤
+│ 400644 │ BGPKIT-LLC │ BGPKIT LLC │ BL-1057-ARIN │ US          │ 1        │
+╰────────┴────────────┴────────────┴──────────────┴─────────────┴──────────╯
 ```
+
+You can specify multiple queries:
+
+```text
+➜  monocle whois 13335 bgpkit               
+╭────────┬───────────────┬──────────────────┬──────────────┬─────────────┬──────────╮
+│ asn    │ as_name       │ org_name         │ org_id       │ org_country │ org_size │
+├────────┼───────────────┼──────────────────┼──────────────┼─────────────┼──────────┤
+│ 13335  │ CLOUDFLARENET │ Cloudflare, Inc. │ CLOUD14-ARIN │ US          │ 5        │
+│ 400644 │ BGPKIT-LLC    │ BGPKIT LLC       │ BL-1057-ARIN │ US          │ 1        │
+╰────────┴───────────────┴──────────────────┴──────────────┴─────────────┴──────────╯
+```
+
+Use `--markdown` to output the table in markdown format:
+```text
+➜  monocle whois 13335 bgpkit --markdown
+| asn    | as_name       | org_name         | org_id       | org_country | org_size |
+|--------|---------------|------------------|--------------|-------------|----------|
+| 13335  | CLOUDFLARENET | Cloudflare, Inc. | CLOUD14-ARIN | US          | 5        |
+| 400644 | BGPKIT-LLC    | BGPKIT LLC       | BL-1057-ARIN | US          | 1        |
+```
+
+| asn    | as_name       | org_name         | org_id       | org_country | org_size |
+|--------|---------------|------------------|--------------|-------------|----------|
+| 13335  | CLOUDFLARENET | Cloudflare, Inc. | CLOUD14-ARIN | US          | 5        |
+| 400644 | BGPKIT-LLC    | BGPKIT LLC       | BL-1057-ARIN | US          | 1        |
+
 
 ## Built with ❤️ by BGPKIT Team
 

--- a/src/monocle.rs
+++ b/src/monocle.rs
@@ -425,7 +425,7 @@ fn main() {
 
             match markdown {
                 true => {
-                    println!("{}", Table::new(res).with(Style::github_markdown()));
+                    println!("{}", Table::new(res).with(Style::markdown()));
                 }
                 false => {
                     println!("{}", Table::new(res).with(Style::rounded()));

--- a/src/monocle.rs
+++ b/src/monocle.rs
@@ -227,6 +227,10 @@ enum Commands {
         /// Refresh local as2org database
         #[clap(short, long)]
         update: bool,
+
+        /// Output to markdown table
+        #[clap(short, long)]
+        markdown: bool,
     },
     /// Time conversion utilities
     Time {
@@ -384,7 +388,7 @@ fn main() {
             // wait for the output thread to stop
             writer_thread.join().unwrap();
         }
-        Commands::Whois { query, name_only, asn_only ,update} => {
+        Commands::Whois { query, name_only, asn_only ,update, markdown} => {
             let data_dir = config.data_dir.as_str();
             let as2org = As2org::new(&Some(format!("{}/monocle-data.sqlite3", data_dir))).unwrap();
 
@@ -418,7 +422,15 @@ fn main() {
             let res = query.into_iter().flat_map(|q| {
                 as2org.search(q.as_str(), &search_type).unwrap()
             }).collect::<Vec<SearchResult>>();
-            println!("{}", Table::new(res).with(Style::github_markdown());
+
+            match markdown {
+                true => {
+                    println!("{}", Table::new(res).with(Style::github_markdown()));
+                }
+                false => {
+                    println!("{}", Table::new(res).with(Style::rounded()));
+                }
+            }
         }
         Commands::Time { time} => {
             match time_to_table(&time) {


### PR DESCRIPTION

`monocle  whois 13335 bgpkit` generates:
```
╭────────┬───────────────┬──────────────────┬──────────────┬─────────────┬──────────╮
│ asn    │ as_name       │ org_name         │ org_id       │ org_country │ org_size │
├────────┼───────────────┼──────────────────┼──────────────┼─────────────┼──────────┤
│ 13335  │ CLOUDFLARENET │ Cloudflare, Inc. │ CLOUD14-ARIN │ US          │ 5        │
│ 400644 │ BGPKIT-LLC    │ BGPKIT LLC       │ BL-1057-ARIN │ US          │ 1        │
╰────────┴───────────────┴──────────────────┴──────────────┴─────────────┴──────────╯
```

`monocle whois 13335 bgpkit --markdown` produces:
```
| asn    | as_name       | org_name         | org_id       | org_country | org_size |
|--------|---------------|------------------|--------------|-------------|----------|
| 13335  | CLOUDFLARENET | Cloudflare, Inc. | CLOUD14-ARIN | US          | 5        |
| 400644 | BGPKIT-LLC    | BGPKIT LLC       | BL-1057-ARIN | US          | 1        |
```

| asn    | as_name       | org_name         | org_id       | org_country | org_size |
|--------|---------------|------------------|--------------|-------------|----------|
| 13335  | CLOUDFLARENET | Cloudflare, Inc. | CLOUD14-ARIN | US          | 5        |
| 400644 | BGPKIT-LLC    | BGPKIT LLC       | BL-1057-ARIN | US          | 1        |



This fixes #13.