### PR TITLE
add sqlite message store and progress bar support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +427,12 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -748,6 +768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +958,7 @@ dependencies = [
  "clap",
  "config",
  "dirs",
+ "indicatif",
  "ipnetwork",
  "itertools",
  "oneio",
@@ -1006,6 +1038,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1551,6 +1589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,8 @@ reqwest = {version = "0.11", features = ["blocking"]}
 regex = "1.6.0"
 oneio = "0.3.0"
 
+# progress bar
+indicatif = "0.17.0"
+
 [features]
 scouter = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod as2org;
 mod database;
+mod msg_store;
 
 use std::net::IpAddr;
 use bgpkit_parser::BgpkitParser;
@@ -13,6 +14,7 @@ use tabled::{Style, Table, Tabled};
 pub use crate::config::MonocleConfig;
 pub use crate::database::MonocleDatabase;
 pub use crate::as2org::*;
+pub use crate::msg_store::MsgStore;
 
 pub fn parser_with_filters(
     file_path: &str,

--- a/src/msg_store.rs
+++ b/src/msg_store.rs
@@ -1,0 +1,113 @@
+use bgpkit_parser::BgpElem;
+use itertools::Itertools;
+use crate::MonocleDatabase;
+
+macro_rules! option_to_string{
+    ($a:expr) => {
+        if let Some(v) = $a {
+            v.to_string()
+        } else {
+            String::new()
+        }
+    }
+}
+
+pub struct MsgStore {
+    db: MonocleDatabase,
+}
+
+impl MsgStore {
+    pub fn new(db_path: &Option<String>, reset: bool) -> MsgStore {
+        let mut db = MonocleDatabase::new(db_path).unwrap();
+        Self::initialize_msgs_db(&mut db, reset);
+        MsgStore{db}
+    }
+
+    fn initialize_msgs_db(db: &mut MonocleDatabase, reset: bool) {
+        db.conn.execute(r#"
+        create table if not exists elems (
+            timestamp INTEGER,
+            elem_type TEXT,
+            peer_ip TEXT,
+            peer_asn INTEGER,
+            prefix TEXT,
+            next_hop TEXT,
+            as_path TEXT,
+            origin_asns TEXT,
+            origin TEXT,
+            local_pref INTEGER,
+            med INTEGER,
+            communities TEXT,
+            atomic TEXT,
+            aggr_asn INTEGER,
+            aggr_ip TEXT
+        );
+        "#,[]).unwrap();
+
+        if reset {
+            db.conn.execute("delete from elems", []).unwrap();
+        }
+    }
+
+    #[inline(always)]
+    fn option_to_string_communities(o: &Option<Vec<bgpkit_parser::MetaCommunity>>) -> String {
+        if let Some(v) = o {
+            v.iter()
+                .join(" ")
+        } else {
+            String::new()
+        }
+    }
+
+    pub fn insert_elems(&self, elems: &[BgpElem]) {
+        for elems in elems.chunks(100){
+            let values = elems.iter().map(|elem|{
+                let t = match elem.elem_type {
+                    bgpkit_parser::ElemType::ANNOUNCE => "A",
+                    bgpkit_parser::ElemType::WITHDRAW => "W",
+                };
+                let origin_string = elem.origin_asns.as_ref().map(|asns| asns.get(0).unwrap());
+                format!(
+                    "('{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}')",
+                    elem.timestamp as u32,
+                    t,
+                    elem.peer_ip,
+                    elem.peer_asn,
+                    elem.prefix,
+                    option_to_string!(&elem.next_hop),
+                    option_to_string!(&elem.as_path),
+                    option_to_string!(origin_string),
+                    option_to_string!(&elem.origin),
+                    option_to_string!(&elem.local_pref),
+                    option_to_string!(&elem.med),
+                    Self::option_to_string_communities(&elem.communities),
+                    option_to_string!(&elem.atomic),
+                    option_to_string!(&elem.aggr_asn),
+                    option_to_string!(&elem.aggr_ip),
+                )
+            }).join(", ").to_string();
+            let query = format!(
+                "INSERT INTO elems (\
+            timestamp, elem_type, peer_ip, peer_asn, prefix, next_hop, \
+            as_path, origin_asns, origin, local_pref, med, communities,\
+            atomic, aggr_asn, aggr_ip)\
+            VALUES {};", values
+            );
+            self.db.conn.execute(query.as_str(), []).unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bgpkit_parser::BgpkitParser;
+    use super::*;
+
+    #[test]
+    fn test_insert() {
+        let store = MsgStore::new(&Some("test.sqlite".to_string()), false);
+        let url = "https://spaces.bgpkit.org/parser/update-example.gz";
+        let elems: Vec<BgpElem> = BgpkitParser::new(url).unwrap().into_elem_iter().collect();
+        store.insert_elems(&elems);
+    }
+}


### PR DESCRIPTION
This pull request added support for saving search results into SQLite databases for processing and analysis.

There are two optional `search` command parameters added:
- `sqlite-path`: specifying a path for storing search results. With `sqlite-path` specified, no regular message output is printed out, and a progress bar will shown.
- `sqlite-reset`: a flag when set will delete the content from the sqlite database if it exists already.

This resovles #20.

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/659667/184516842-2ea6045b-751c-4f22-875e-798fa8e9617f.png">

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/659667/184516845-3a0d781a-9ca8-4433-b46d-6738dcb90177.png">

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/659667/184516864-90c41e88-d450-4e28-a70c-647f39fa6bca.png">
