### PR TITLE
allow floating point number timestamp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@ pub fn string_to_time(time_string: &str) -> Result<i64> {
             ts.timestamp()
         }
         Err(_) => {
-            match time_string.parse::<i64>(){
-                Ok(ts) => ts,
+            match time_string.parse::<f64>(){
+                Ok(ts) => ts as i64,
                 Err(_) => return Err(anyhow!("Input time must be either Unix timestamp or time string compliant with RFC3339"))
             }
         }


### PR DESCRIPTION
```
➜  monocle git:(feature/order-results) ✗ cargo run -- time 0                    
   Compiling monocle v0.2.2 (/Users/mingwei/Warehouse/BGPKIT/bgpkit-git/monocle)
    Finished dev [unoptimized + debuginfo] target(s) in 2.18s
     Running `target/debug/monocle time 0`
╭──────┬───────────────────────────┬──────────────╮
│ unix │ rfc3339                   │ human        │
├──────┼───────────────────────────┼──────────────┤
│ 0    │ 1970-01-01T00:00:00+00:00 │ 53 years ago │
╰──────┴───────────────────────────┴──────────────╯
➜  monocle git:(bugfix/floating-number-timestamp) ✗ cargo run -- time 0.0
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/monocle time 0.0`
╭──────┬───────────────────────────┬──────────────╮
│ unix │ rfc3339                   │ human        │
├──────┼───────────────────────────┼──────────────┤
│ 0    │ 1970-01-01T00:00:00+00:00 │ 53 years ago │
╰──────┴───────────────────────────┴──────────────╯
➜  monocle git:(bugfix/floating-number-timestamp) ✗ cargo run -- time 0.1234567
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/monocle time 0.1234567`
╭──────┬───────────────────────────┬──────────────╮
│ unix │ rfc3339                   │ human        │
├──────┼───────────────────────────┼──────────────┤
│ 0    │ 1970-01-01T00:00:00+00:00 │ 53 years ago │
╰──────┴───────────────────────────┴──────────────╯
```