### PR TITLE
order search results by AS number

### DIFF
--- a/src/monocle.rs
+++ b/src/monocle.rs
@@ -498,9 +498,12 @@ fn main() {
                 search_type = SearchType::CountryOnly;
             }
 
-            let res = query.into_iter().flat_map(|q| {
+            let mut res = query.into_iter().flat_map(|q| {
                 as2org.search(q.as_str(), &search_type, full_country).unwrap()
             }).collect::<Vec<SearchResult>>();
+
+            // order search results by AS number
+            res.sort_by_key(|v| v.asn);
 
             match concise {
                 true => {


### PR DESCRIPTION
```
➜  monocle git:(feature/order-results) ✗ cargo run -- whois -cm 400644 702 13335
   Compiling monocle v0.2.2 (/Users/mingwei/Warehouse/BGPKIT/bgpkit-git/monocle)
    Finished dev [unoptimized + debuginfo] target(s) in 1.40s
     Running `target/debug/monocle whois -cm 400644 702 13335`
| asn    | as_name       | org_name         | org_country |
|--------|---------------|------------------|-------------|
| 702    | UUNET         | Verizon Business | US          |
| 13335  | CLOUDFLARENET | Cloudflare, Inc. | US          |
| 400644 | BGPKIT-LLC    | BGPKIT LLC       | US          |
```