### PR TITLE
add rpki subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bcder"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dfb7dc0d4aee3f8c723c43553b55662badf692b541ff8e4426df75dae8da9a"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "bgp-models"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,7 +258,7 @@ checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive 4.1.0",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -292,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -949,9 +959,9 @@ checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1130,10 +1140,11 @@ dependencies = [
  "indicatif",
  "ipnetwork 0.20.0",
  "itertools",
- "oneio 0.7.1",
+ "oneio 0.7.2",
  "rayon",
  "regex",
  "reqwest",
+ "rpki",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1245,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "oneio"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c37bf9d8d1e43d26ce8b1bc272f483d227d9feb7d499904db513faa3bc0c722"
+checksum = "7c25a23a9c1280fcce0139d8d273c2b75fbe6018814c6e65c98ba8ee1fa6c4c0"
 dependencies = [
  "bzip2",
  "clap 4.1.6",
@@ -1590,6 +1601,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "routecore"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd872857e85411c0ba7d18dfe650fc4864b292c02cde997e86c511314fdfc3"
+dependencies = [
+ "bcder",
+]
+
+[[package]]
+name = "rpki"
+version = "0.15.10-dev"
+source = "git+https://github.com/bgpkit/rpki-rs.git?branch=expose-roa-inner#55ea37fb70efb041338f846a25debeecf417028b"
+dependencies = [
+ "base64 0.13.1",
+ "bcder",
+ "bytes",
+ "chrono",
+ "log",
+ "ring",
+ "routecore",
+ "untrusted",
+ "uuid",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -1801,9 +1837,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2112,6 +2148,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "monocle"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bgpkit-broker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ dirs = "4"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 reqwest = {version = "0.11", features = ["blocking"]}
 regex = "1.6.0"
-oneio = "0.7.1"
+oneio = "0.7.2"
+rpki = {git="https://github.com/bgpkit/rpki-rs.git", branch = "expose-roa-inner", features = ["repository"]}
 
 # progress bar
 indicatif = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monocle"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -271,11 +271,73 @@ Example runs:
 ╰──────┴──────────────────────────────────────╯
 ```
 
+### `monocle rpki`: 
+Check RPKI validity for given prefix-ASN pair and provide utility to read ROA and ASPA files from the RPKI archive.
+
+```text
+➜  monocle rpki --help
+RPKI utility module
+
+Usage: monocle rpki <COMMAND>
+
+Commands:
+  roa    parse a RPKI ROA file
+  aspa   parse a RPKI ASPA file
+  check  validate a prefix-asn pair with a RPKI validator
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+```
+
+#### `monocle rpki check`
+
+Check RPKI validity for given prefix-ASN pair. We use RIPE NCC's [routinator instance](https://rpki-validator.ripe.net) as the data source.
+
+```text
+➜  monocle rpki check --help
+validate a prefix-asn pair with a RPKI validator
+
+Usage: monocle rpki check --asn <ASN> --prefix <PREFIX>
+
+Options:
+  -a, --asn <ASN>        
+  -p, --prefix <PREFIX>  
+  -h, --help             Print help
+  -V, --version          Print version
+```
+
+#### `monocle rpki roa`
+Parse a given RPKI ROA file and display the prefix-ASN pairs with max length.
+
+```text
+➜  monocle rpki roa https://spaces.bgpkit.org/parser/bgpkit.roa
+
+| asn    | prefix            | max_len |
+|--------|-------------------|---------|
+| 393949 | 192.67.222.0/24   | 24      |
+| 393949 | 192.195.251.0/24  | 24      |
+| 393949 | 2620:98:4000::/44 | 48      |
+```
+
+#### `monocle rpki aspa`
+
+Parse a given RPKI ASPA file and display the allowed upstreams.
+
+```text
+➜  monocle rpki aspa https://spaces.bgpkit.org/parser/as945.asa
+| asn | allowed_upstream |
+|-----|------------------|
+| 945 | 1299             |
+|     | 6939             |
+|     | 7480             |
+|     | 32097            |
+|     | 50058            |
+|     | 61138            |
+```
 
 ## Built with ❤️ by BGPKIT Team
-
-BGPKIT is a small-team focuses on building the best open-source tooling for BGP data processing in Rust. We have over 10 years of
-experience in working with BGP data and we believe that our work can enable more companies to start keeping tracks of BGP data
-on their own turf. Learn more about what we do at https://bgpkit.com.
 
 <a href="https://bgpkit.com"><img src="https://bgpkit.com/Original%20Logo%20Cropped.png" alt="https://bgpkit.com/favicon.ico" width="200"/></a>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod as2org;
 mod database;
 mod msg_store;
 mod country;
+mod rpki;
 
 use std::net::IpAddr;
 use bgpkit_parser::BgpkitParser;
@@ -17,6 +18,7 @@ pub use crate::database::MonocleDatabase;
 pub use crate::as2org::*;
 pub use crate::msg_store::MsgStore;
 pub use crate::country::CountryLookup;
+pub use crate::rpki::*;
 
 pub fn parser_with_filters(
     file_path: &str,

--- a/src/rpki.rs
+++ b/src/rpki.rs
@@ -1,0 +1,112 @@
+use std::io::Read;
+use std::str::FromStr;
+use rpki::repository::Roa;
+use anyhow::{anyhow, Result};
+use ipnetwork::IpNetwork;
+use rpki::repository::aspa::Aspa;
+use serde_json::Value;
+use tabled::Tabled;
+
+#[derive(Debug, Tabled)]
+pub struct RoaObject {
+    pub asn: u32,
+    pub prefix: IpNetwork,
+    pub max_len: u8,
+}
+
+pub fn read_roa(file_path: &str) -> Result<Vec<RoaObject>> {
+    let mut data = vec![];
+    let mut reader = oneio::get_reader(file_path)?;
+    reader.read_to_end(&mut data)?;
+    let roa = Roa::decode(data.as_ref(), true)?;
+    let asn: u32 = roa.content.as_id().into_u32();
+    let objects = roa.content.iter()
+        .map(|addr| {
+            let prefix_str = addr.to_string();
+            let fields = prefix_str.as_str().split('/').collect::<Vec<&str>>();
+            let p = format!("{}/{}", fields[0], fields[1]);
+            let prefix = IpNetwork::from_str(p.as_str()).unwrap();
+            let max_len = addr.max_length();
+            RoaObject{
+                asn,
+                prefix,
+                max_len
+            }
+        }).collect();
+    Ok(objects)
+}
+
+#[derive(Debug, Tabled)]
+pub struct AspaObject {
+    pub asn: u32,
+    pub allowed_upstream: u32,
+}
+
+pub fn read_aspa(file_path: &str) -> Result<Vec<AspaObject>> {
+    let mut data = vec![];
+    let mut reader = oneio::get_reader(file_path)?;
+    reader.read_to_end(&mut data)?;
+    let aspa = Aspa::decode(data.as_ref(), true)?;
+    let customer = aspa.content.customer_as().into_u32();
+    let res = aspa.content.provider_as_set().iter()
+        .map(|p|
+            AspaObject{ asn: customer, allowed_upstream: p.provider().into_u32()}
+            ).collect();
+    Ok(res)
+}
+
+#[derive(Debug, Tabled)]
+pub struct RpkiValidity {
+    asn: u32,
+    prefix: IpNetwork,
+    validity: String,
+}
+
+/// https://rpki-validator.ripe.net/api/v1/validity/13335/1.1.0.0/23
+pub fn rpki_validate(asn: u32, prefix_str: &str) -> Result<RpkiValidity> {
+    let prefix = IpNetwork::from_str(prefix_str)?;
+    let url = format!("https://rpki-validator.ripe.net/api/v1/validity/{}/{}/{}", asn, prefix.network(), prefix.prefix());
+    match oneio::read_to_string(url.as_str()) {
+        Ok(content) => {
+            let res: Value = match serde_json::from_str(content.as_str()){
+                Ok(v) => {v},
+                Err(_e) => {
+                    return Err(anyhow!("invalid asn or prefix"))
+                }
+            };
+            let validity = res.get("validated_route").unwrap().get("validity").unwrap().as_object().unwrap().get("state").unwrap().as_str().unwrap().to_string();
+            Ok(RpkiValidity{asn, prefix, validity})
+        }
+        Err(_e) => {
+            Err(anyhow!("invalid asn or prefix"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_read_roa() {
+        let objects = read_roa("https://spaces.bgpkit.org/parser/bgpkit.roa").unwrap();
+        dbg!(objects);
+
+        let res = read_aspa("https://spaces.bgpkit.org/parser/as945.asa").unwrap();
+        dbg!(res);
+    }
+
+    #[test]
+    fn test_rpki_validate() -> Result<()> {
+        let res = rpki_validate(13335, "1.1.1.0/23")?;
+        dbg!(res);
+        let res = rpki_validate(13335, "1.1.1.0/24")?;
+        dbg!(res);
+        let res = rpki_validate(13335, "1.1.1.0/25")?;
+        dbg!(res);
+        let res = rpki_validate(400644, "2620:AA:A000::/48")?;
+        dbg!(res);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Check RPKI validity for given prefix-ASN pair and provide utility to read ROA and ASPA files from the RPKI archive.

```text
➜  monocle rpki --help
RPKI utility module

Usage: monocle rpki <COMMAND>

Commands:
  roa    parse a RPKI ROA file
  aspa   parse a RPKI ASPA file
  check  validate a prefix-asn pair with a RPKI validator
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

```

#### `monocle rpki check`

Check RPKI validity for given prefix-ASN pair. We use RIPE NCC's [routinator instance](https://rpki-validator.ripe.net) as the data source.

```text
➜  monocle rpki check --help
validate a prefix-asn pair with a RPKI validator

Usage: monocle rpki check --asn <ASN> --prefix <PREFIX>

Options:
  -a, --asn <ASN>        
  -p, --prefix <PREFIX>  
  -h, --help             Print help
  -V, --version          Print version
```

#### `monocle rpki roa`
Parse a given RPKI ROA file and display the prefix-ASN pairs with max length.

```text
➜  monocle rpki roa https://spaces.bgpkit.org/parser/bgpkit.roa

| asn    | prefix            | max_len |
|--------|-------------------|---------|
| 393949 | 192.67.222.0/24   | 24      |
| 393949 | 192.195.251.0/24  | 24      |
| 393949 | 2620:98:4000::/44 | 48      |
```

#### `monocle rpki aspa`

Parse a given RPKI ASPA file and display the allowed upstreams.

```text
➜  monocle rpki aspa https://spaces.bgpkit.org/parser/as945.asa
| asn | allowed_upstream |
|-----|------------------|
| 945 | 1299             |
|     | 6939             |
|     | 7480             |
|     | 32097            |
|     | 50058            |
|     | 61138            |
```
