### PR TITLE
Properly write nullable values to sqlite

### DIFF
--- a/src/monocle.rs
+++ b/src/monocle.rs
@@ -491,7 +491,7 @@ fn main() {
                     for elem in receiver {
                         msg_count += 1;
                         msg_cache.push(elem);
-                        if msg_cache.len() >= 500 {
+                        if msg_cache.len() >= 100000 {
                             db.insert_elems(&msg_cache);
                             msg_cache.clear();
                         }

--- a/src/msg_store.rs
+++ b/src/msg_store.rs
@@ -65,7 +65,7 @@ impl MsgStore {
     }
 
     pub fn insert_elems(&self, elems: &[BgpElem]) {
-        for elems in elems.chunks(100) {
+        for elems in elems.chunks(10000) {
             let values = elems
                 .iter()
                 .map(|elem| {

--- a/src/msg_store.rs
+++ b/src/msg_store.rs
@@ -6,9 +6,9 @@ use itertools::Itertools;
 macro_rules! option_to_string {
     ($a:expr) => {
         if let Some(v) = $a {
-            v.to_string()
+            format!("'{}'", v)
         } else {
-            String::new()
+            "NULL".to_string()
         }
     };
 }
@@ -58,9 +58,9 @@ impl MsgStore {
     #[inline(always)]
     fn option_to_string_communities(o: &Option<Vec<MetaCommunity>>) -> String {
         if let Some(v) = o {
-            v.iter().join(" ")
+            format!("'{}'", v.iter().join(" "))
         } else {
-            String::new()
+            "NULL".to_string()
         }
     }
 
@@ -77,23 +77,23 @@ impl MsgStore {
                     };
                     let origin_string = elem.origin_asns.as_ref().map(|asns| asns.get(0).unwrap());
                     format!(
-                    "('{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}','{}')",
-                    elem.timestamp as u32,
-                    t,
-                    elem.peer_ip,
-                    elem.peer_asn,
-                    elem.prefix,
-                    option_to_string!(&elem.next_hop),
-                    option_to_string!(&elem.as_path),
-                    option_to_string!(origin_string),
-                    option_to_string!(&elem.origin),
-                    option_to_string!(&elem.local_pref),
-                    option_to_string!(&elem.med),
-                    Self::option_to_string_communities(&elem.communities),
-                    option_to_string!(&elem.atomic),
-                    option_to_string!(&elem.aggr_asn),
-                    option_to_string!(&elem.aggr_ip),
-                )
+                        "('{}','{}','{}','{}','{}', {},{},{},{},{},{},{},{},{},{})",
+                        elem.timestamp as u32,
+                        t,
+                        elem.peer_ip,
+                        elem.peer_asn,
+                        elem.prefix,
+                        option_to_string!(&elem.next_hop),
+                        option_to_string!(&elem.as_path),
+                        option_to_string!(origin_string),
+                        option_to_string!(&elem.origin),
+                        option_to_string!(&elem.local_pref),
+                        option_to_string!(&elem.med),
+                        Self::option_to_string_communities(&elem.communities),
+                        option_to_string!(&elem.atomic),
+                        option_to_string!(&elem.aggr_asn),
+                        option_to_string!(&elem.aggr_ip),
+                    )
                 })
                 .join(", ")
                 .to_string();


### PR DESCRIPTION
This PR fixes writing nullable values to SQLite columns. Previously, empty strings were written as values to the columns instead of NULLs.

This PR fixes #47.