### PR TITLE
add cloudflare radar API queries support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 .idea
 *.sqlite3
+
+.env*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1092,7 @@ dependencies = [
  "ipnetwork",
  "itertools",
  "oneio 0.11.0",
+ "radar-rs",
  "rayon",
  "regex",
  "rpki",
@@ -1414,6 +1421,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radar-rs"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65b3d4f8b54ac753d05c26b7107b120d5f96411c4d7b7fe19f2e95906f0557d"
+dependencies = [
+ "dotenvy",
+ "reqwest",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ ureq = {version="2.6.2", features=["json"]}
 regex = "1.6.0"
 oneio = "0.11.0"
 rpki = {version= "0.16.1", features = ["repository"]}
+radar-rs = "0.0.2"
 
 # progress bar
 indicatif = "0.17.0"

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -1,7 +1,9 @@
 mod as2org;
 mod country;
+mod radar;
 mod rpki;
 
 pub use crate::datasets::as2org::*;
 pub use crate::datasets::country::*;
+pub use crate::datasets::radar::*;
 pub use crate::datasets::rpki::*;

--- a/src/datasets/radar.rs
+++ b/src/datasets/radar.rs
@@ -1,0 +1,35 @@
+//! Cloudflare Radar data access.
+//!
+//! Note: using this module requires setting CF_API_TOKEN in environment variables
+
+use radar_rs::{PrefixOriginsResult, RadarClient, RadarError, RoutingStatsResult};
+
+pub struct CfRadar {
+    client: RadarClient,
+}
+
+impl CfRadar {
+    pub fn new() -> Result<Self, RadarError> {
+        Ok(Self {
+            client: RadarClient::new()?,
+        })
+    }
+
+    pub fn get_bgp_routing_stats(
+        &self,
+        asn: Option<u32>,
+        country_code: Option<String>,
+    ) -> Result<RoutingStatsResult, RadarError> {
+        self.client.get_bgp_routing_stats(asn, country_code)
+    }
+
+    pub fn get_prefix_origins(
+        &self,
+        origin: Option<u32>,
+        prefix: Option<String>,
+        rpki_status: Option<String>,
+    ) -> Result<PrefixOriginsResult, RadarError> {
+        self.client
+            .get_bgp_prefix_origins(origin, prefix, rpki_status)
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds support for querying [Cloudflare Radar][radar] new BGP [routing statistics][routing-stats] and [prefix-to-origin mapping][prefix-to-origin] APIs.

[radar]: https://radar.cloudflare.com/
[routing-stats]: https://developers.cloudflare.com/api/operations/radar-get-bgp-routes-stats
[prefix-to-origin]: https://developers.cloudflare.com/api/operations/radar-get-bgp-pfx2as

This feature is powered by [`radar-rs: 0.0.2`](https://docs.rs/radar-rs/0.0.2/radar_rs/index.html), an unofficial Cloudflare Radar API Rust SDK. This library is still in very early stage.

## Usage

We added a new `monocle radar` command group in this pull request, which contains the following to subcommands:
- `monocle radar stats [QUERY]`: get routing stats (like prefix count, rpki invalid count) for a given country or ASN.
- `monocle radar pfx2as [QUERY] [--rpki-status valid|invalid|unknown]`: get prefix to origin mapping for a given prefix or ASN

<img width="665" alt="image" src="https://github.com/bgpkit/monocle/assets/659667/d83c4d5e-ee79-4342-afec-163428a799b1">

<img width="582" alt="image" src="https://github.com/bgpkit/monocle/assets/659667/30ef0f5e-056e-4070-87dd-4e7bef6d436d">

## API Token Required

We do not provide data access in the tool. Users who want to access this data are required to obtain a Cloudflare API token (see [this tutorial](https://developers.cloudflare.com/radar/get-started/first-request/)) and set the environment variable `CF_API_TOKEN` with the token content. Commands will fail should the token be missing or invalid.

## Data License

The use of the Cloudflare Radar data is under [`CC BY-SA 4.0`](https://creativecommons.org/licenses/by-nc/4.0/) license.

This library does not provide any direct access to the API data.

See [Cloudflare Radar about page](https://radar.cloudflare.com/about) for more details.