### PR TITLE
add new `ip` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,14 @@ itertools = "0.13.0"
 rayon = "1.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-ipnetwork = { version = "0.20.0", default-features = false }
+ipnet = { version = "2.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
 chrono-humanize = "0.2"
 anyhow = "1.0"
-tabled = "0.15.0"
+json_to_table = "0.9.0"
+tabled = "0.17.0"
 config = { version = "0.13", features = ["toml"] }
 dirs = "5"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/src/datasets/ip.rs
+++ b/src/datasets/ip.rs
@@ -32,11 +32,16 @@ pub struct IpInfo {
     pub asn: Option<AsnRouteInfo>,
 }
 
-pub fn fetch_ip_info(ip_opt: Option<IpAddr>) -> Result<IpInfo> {
-    let url = match ip_opt {
-        Some(ip) => format!("https://api.bgpkit.com/v3/utils/ip?ip={}", ip),
-        None => "https://api.bgpkit.com/v3/utils/ip".to_string(),
-    };
+const IP_INFO_API: &str = "https://api.bgpkit.com/v3/utils/ip";
+pub fn fetch_ip_info(ip_opt: Option<IpAddr>, simple: bool) -> Result<IpInfo> {
+    let mut params = vec![];
+    if let Some(ip) = ip_opt {
+        params.push(format!("ip={}", ip));
+    }
+    if simple {
+        params.push("simple=true".to_string());
+    }
+    let url = format!("{}?{}", IP_INFO_API, params.join("&"));
     let resp = ureq::get(&url).call()?.into_json::<IpInfo>()?;
     Ok(resp)
 }
@@ -47,7 +52,7 @@ mod tests {
 
     #[test]
     fn test_fetch_ip_info() {
-        let my_public_ip_info = fetch_ip_info(None).unwrap();
+        let my_public_ip_info = fetch_ip_info(None, false).unwrap();
         dbg!(my_public_ip_info);
     }
 }

--- a/src/datasets/ip.rs
+++ b/src/datasets/ip.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RpkiValidationState {
+    #[serde(rename = "valid")]
+    Valid,
+    #[serde(rename = "invalid")]
+    Invalid,
+    #[serde(rename = "unknown")]
+    NotFound,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsnRouteInfo {
+    pub asn: i64,
+    #[serde(rename(serialize = "prefix"))]
+    pub prefix: IpNet,
+    pub rpki: RpkiValidationState,
+    pub name: String,
+    pub country: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpInfo {
+    pub ip: String,
+    #[serde(rename(serialize = "location"))]
+    pub country: String,
+    #[serde(rename(serialize = "network"))]
+    pub asn: Option<AsnRouteInfo>,
+}
+
+pub fn fetch_ip_info(ip_opt: Option<IpAddr>) -> Result<IpInfo> {
+    let url = match ip_opt {
+        Some(ip) => format!("https://api.bgpkit.com/v3/utils/ip?ip={}", ip),
+        None => "https://api.bgpkit.com/v3/utils/ip".to_string(),
+    };
+    let resp = ureq::get(&url).call()?.into_json::<IpInfo>()?;
+    Ok(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_ip_info() {
+        let my_public_ip_info = fetch_ip_info(None).unwrap();
+        dbg!(my_public_ip_info);
+    }
+}

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -1,9 +1,11 @@
 mod as2org;
 mod country;
+mod ip;
 mod radar;
 mod rpki;
 
 pub use crate::datasets::as2org::*;
 pub use crate::datasets::country::*;
+pub use crate::datasets::ip::*;
 pub use crate::datasets::radar::*;
 pub use crate::datasets::rpki::*;

--- a/src/datasets/rpki/roa.rs
+++ b/src/datasets/rpki/roa.rs
@@ -1,13 +1,13 @@
-use std::str::FromStr;
 use anyhow::Result;
-use ipnetwork::IpNetwork;
+use ipnet::IpNet;
 use rpki::repository::Roa;
+use std::str::FromStr;
 use tabled::Tabled;
 
 #[derive(Debug, Tabled)]
 pub struct RoaObject {
     pub asn: u32,
-    pub prefix: IpNetwork,
+    pub prefix: IpNet,
     pub max_len: u8,
 }
 
@@ -17,19 +17,21 @@ pub fn read_roa(file_path: &str) -> Result<Vec<RoaObject>> {
     reader.read_to_end(&mut data)?;
     let roa = Roa::decode(data.as_ref(), true)?;
     let asn: u32 = roa.content().as_id().into_u32();
-    let objects = roa.content().iter()
+    let objects = roa
+        .content()
+        .iter()
         .map(|addr| {
             let prefix_str = addr.to_string();
             let fields = prefix_str.as_str().split('/').collect::<Vec<&str>>();
             let p = format!("{}/{}", fields[0], fields[1]);
-            let prefix = IpNetwork::from_str(p.as_str()).unwrap();
+            let prefix = IpNet::from_str(p.as_str()).unwrap();
             let max_len = addr.max_length();
-            RoaObject{
+            RoaObject {
                 asn,
                 prefix,
-                max_len
+                max_len,
             }
-        }).collect();
+        })
+        .collect();
     Ok(objects)
 }
-

--- a/src/datasets/rpki/validator.rs
+++ b/src/datasets/rpki/validator.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ipnetwork::IpNetwork;
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::{Display, Formatter};
@@ -9,7 +9,7 @@ use tabled::Tabled;
 #[derive(Debug, Tabled)]
 pub struct RpkiValidity {
     asn: u32,
-    prefix: IpNetwork,
+    prefix: IpNet,
     validity: ValidationState,
 }
 
@@ -123,7 +123,7 @@ impl Display for ValidationState {
 
 /// https://rpki-validator.ripe.net/api/v1/validity/13335/1.1.0.0/23
 pub fn validate(asn: u32, prefix_str: &str) -> Result<(RpkiValidity, Vec<Roa>)> {
-    let prefix = IpNetwork::from_str(prefix_str)?;
+    let prefix = IpNet::from_str(prefix_str)?;
     let query_string = format!(
         r#"
     query GetValidation {{
@@ -164,7 +164,7 @@ pub fn validate(asn: u32, prefix_str: &str) -> Result<(RpkiValidity, Vec<Roa>)> 
     ))
 }
 
-pub fn list_by_prefix(prefix: &IpNetwork) -> Result<Vec<RoaResource>> {
+pub fn list_by_prefix(prefix: &IpNet) -> Result<Vec<RoaResource>> {
     let query_string = format!(
         r#"
     query GetResources {{
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_list_prefix() {
-        let res = list_by_prefix(&"1.0.0.0/25".parse::<IpNetwork>().unwrap()).unwrap();
+        let res = list_by_prefix(&"1.0.0.0/25".parse::<IpNet>().unwrap()).unwrap();
         dbg!(&res);
     }
 


### PR DESCRIPTION
Add new `monocle ip [OPTIONS] [IP]` command.

## Usage

Help information:
```
monocle ip  --help         
IP information lookup

Usage: monocle ip [OPTIONS] [IP]

Arguments:
  [IP]  IP address to look up (optional)

Options:
      --simple   Print IP address only (e.g. for getting the public IP address quickly)
      --json     Output as JSON objects
  -h, --help     Print help
  -V, --version  Print version
```

Retrieve current public IP information:
```
➜  monocle ip
+----------+--------------------------+
| ip       | X.X.X.X                  |
+----------+--------------------------+
| location | US                       |
+----------+---------+----------------+
| network  | asn     | 7018           |
|          +---------+----------------+
|          | country | US             |
|          +---------+----------------+
|          | name    | AT&T US - 7018 |
|          +---------+----------------+
|          | prefix  | 104.48.0.0/12  |
|          +---------+----------------+
|          | rpki    | valid          |
+----------+---------+----------------+
```

Print out current public IP only (fastest):
```
➜  monocle ip --simple
10.0.0.0
````

Query IP information with a specific IP address:
```
➜  monocle ip 1.1.1.1

+----------+----------------------+
| ip       | 1.1.1.1              |
+----------+----------------------+
| location | US                   |
+----------+---------+------------+
| route    | asn     | 13335      |
|          +---------+------------+
|          | country | US         |
|          +---------+------------+
|          | name    | Cloudflare |
|          +---------+------------+
|          | prefix  | 1.1.1.0/24 |
|          +---------+------------+
|          | rpki    | valid      |
+----------+---------+------------+
```