### PR TITLE
Improved date parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,34 +17,29 @@ name = "monocle"
 path = "src/bin/monocle.rs"
 
 [dependencies]
+anyhow = "1.0"
 bgpkit-broker = "0.7.5"
 bgpkit-parser = { version = "0.10.11", features = ["serde"] }
-oneio = { version = "0.17.0", default-features = false, features = ["remote", "gz", "bz"] }
-
-clap = { version = "4.1", features = ["derive"] }
-itertools = "0.13.0"
-rayon = "1.8"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-ipnet = { version = "2.10", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 chrono = "0.4"
 chrono-humanize = "0.2"
-anyhow = "1.0"
-json_to_table = "0.9.0"
-tabled = "0.17.0"
-config = { version = "0.13", features = ["toml"] }
+clap = { version = "4.1", features = ["derive"] }
 dirs = "5"
-rusqlite = { version = "0.31", features = ["bundled"] }
-ureq = { version = "2.9", features = ["json"] }
-regex = "1.10"
-rpki = { version = "0.16.1", features = ["repository"] }
-radar-rs = "0.1.0"
 dotenvy = "0.15"
-
-# progress bar
-indicatif = "0.17.0"
+indicatif = "0.17.0" # progress bar
+ipnet = { version = "2.10", features = ["json"] }
+itertools = "0.13.0"
+json_to_table = "0.9.0"
+oneio = { version = "0.17.0", default-features = false, features = ["remote", "gz", "bz"] }
+radar-rs = "0.1.0"
+rayon = "1.8"
+regex = "1.10"
+rusqlite = { version = "0.31", features = ["bundled"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tabled = "0.17.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+ureq = { version = "2.9", features = ["json"] }
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,11 @@ path = "src/bin/monocle.rs"
 anyhow = "1.0"
 bgpkit-broker = "0.7.5"
 bgpkit-parser = { version = "0.10.11", features = ["serde"] }
+config = { version = "0.13", features = ["toml"] }
 chrono = "0.4"
 chrono-humanize = "0.2"
 clap = { version = "4.1", features = ["derive"] }
+dateparser = "0.2"
 dirs = "5"
 dotenvy = "0.15"
 indicatif = "0.17.0" # progress bar
@@ -33,6 +35,7 @@ oneio = { version = "0.17.0", default-features = false, features = ["remote", "g
 radar-rs = "0.1.0"
 rayon = "1.8"
 regex = "1.10"
+rpki = { version = "0.16.1", features = ["repository"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.1", features = ["derive"] }
 dateparser = "0.2"
 dirs = "5"
 dotenvy = "0.15"
+humantime = "2.1"
 indicatif = "0.17.0" # progress bar
 ipnet = { version = "2.10", features = ["json"] }
 itertools = "0.13.0"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Subcommands:
 - `parse`: parse individual MRT files
 - `search`: search for matching messages from all available public MRT files
 - `whois`: search AS and organization information by ASN or name
-- `country`: utility to lookup country name and code
+- `country`: utility to look up country name and code
 - `time`: utility to convert time between unix timestamp and RFC3339 string
 - `rpki`: check RPKI validation for given ASNs or prefixes
 
@@ -75,33 +75,34 @@ Options:
 
 ### `monocle parse`
 
-Parsing single MRT file given a local path or a remote URL.
+Parsing a single MRT file given a local path or a remote URL.
 
 ```text
 ➜  monocle git:(main) ✗ monocle parse --help
 Parse individual MRT files given a file path, local or remote
 
-USAGE:
-    monocle parse [OPTIONS] <FILE>
+Usage: monocle parse [OPTIONS] <FILE>
 
-ARGS:
-    <FILE>    File path to a MRT file, local or remote
+Arguments:
+  <FILE>  File path to a MRT file, local or remote
 
-OPTIONS:
-    -a, --as-path <AS_PATH>          Filter by AS path regex string
-    -h, --help                       Print help information
-    -j, --peer-ip <PEER_IP>          Filter by peer IP address
-    -J, --peer-asn <PEER_ASN>        Filter by peer ASN
-        --json                       Output as JSON objects
-    -m, --elem-type <ELEM_TYPE>      Filter by elem type: announce (a) or withdraw (w)
-    -o, --origin-asn <ORIGIN_ASN>    Filter by origin AS Number
-    -p, --prefix <PREFIX>            Filter by network prefix
-        --pretty                     Pretty-print JSON output
-    -s, --include-super              Include super-prefix when filtering
-    -S, --include-sub                Include sub-prefix when filtering
-    -t, --start-ts <START_TS>        Filter by start unix timestamp inclusive
-    -T, --end-ts <END_TS>            Filter by end unix timestamp inclusive
-    -V, --version                    Print version information
+Options:
+      --json                     Output as JSON objects
+      --debug                    Print debug information
+      --pretty                   Pretty-print JSON output
+  -M, --mrt-path <MRT_PATH>      MRT output file path
+  -o, --origin-asn <ORIGIN_ASN>  Filter by origin AS Number
+  -p, --prefix <PREFIX>          Filter by network prefix
+  -s, --include-super            Include super-prefix when filtering
+  -S, --include-sub              Include sub-prefix when filtering
+  -j, --peer-ip <PEER_IP>        Filter by peer IP address
+  -J, --peer-asn <PEER_ASN>      Filter by peer ASN
+  -m, --elem-type <ELEM_TYPE>    Filter by elem type: announce (a) or withdraw (w)
+  -t, --start-ts <START_TS>      Filter by start unix timestamp inclusive
+  -T, --end-ts <END_TS>          Filter by end unix timestamp inclusive
+  -a, --as-path <AS_PATH>        Filter by AS path regex string
+  -h, --help                     Print help
+  -V, --version                  Print version
 ```
 
 ### `monocle search`
@@ -113,17 +114,19 @@ MRT files in parallel. More filters can be used to search for messages that matc
 ➜  monocle git:(main) ✗ monocle search --help
 Search BGP messages from all available public MRT files
 
-Usage: monocle search [OPTIONS] --start-ts <START_TS> --end-ts <END_TS>
+Usage: monocle search [OPTIONS]
 
 Options:
       --dry-run                    Dry-run, do not download or parse
+      --debug                      Print debug information
       --json                       Output as JSON objects
       --pretty                     Pretty-print JSON output
       --sqlite-path <SQLITE_PATH>  SQLite output file path
-      --mrt-path <MRT_PATH>        MRT output file path
+  -M, --mrt-path <MRT_PATH>        MRT output file path
       --sqlite-reset               SQLite reset database content if exists
   -t, --start-ts <START_TS>        Filter by start unix timestamp inclusive
   -T, --end-ts <END_TS>            Filter by end unix timestamp inclusive
+  -d, --duration <DURATION>        
   -c, --collector <COLLECTOR>      Filter by collector, e.g. rrc00 or route-views2
   -P, --project <PROJECT>          Filter by route collection project, i.e. riperis or routeviews
   -o, --origin-asn <ORIGIN_ASN>    Filter by origin AS Number
@@ -141,6 +144,10 @@ Options:
 ### `monocle time`
 
 Convert between UNIX timestamp and RFC3339 time strings.
+We use the [`dateparser`][dateparser] crate for parsing time
+strings.
+
+[dateparser]:https://github.com/waltzofpearls/dateparser
 
 ```text
 ➜  ~ monocle time --help              
@@ -167,13 +174,6 @@ Example runs:
 ├────────────┼───────────────────────────┼───────┤
 │ 1659135226 │ 2022-07-29T22:53:46+00:00 │ now   │
 ╰────────────┴───────────────────────────┴───────╯
-
-➜  monocle time 0
-╭──────┬───────────────────────────┬──────────────╮
-│ unix │ rfc3339                   │ human        │
-├──────┼───────────────────────────┼──────────────┤
-│ 0    │ 1970-01-01T00:00:00+00:00 │ 52 years ago │
-╰──────┴───────────────────────────┴──────────────╯
 
 ➜  monocle time 2022-01-01T00:00:00Z
 ╭────────────┬───────────────────────────┬──────────────╮
@@ -241,7 +241,7 @@ You can specify multiple queries:
 | 400644 | BGPKIT-LLC    | BGPKIT LLC       | US          |
 ```
 
-Use `--pretty` to output the table with pretty rounded corner
+Use `--pretty` to output the table with a pretty rounded corner
 
 ```text
 ➜  monocle whois 13335 bgpkit --pretty
@@ -325,7 +325,8 @@ Commands:
 
 #### `monocle rpki check`
 
-Check RPKI validity for given prefix-ASN pair. We use RIPE NCC's [routinator instance](https://rpki-validator.ripe.net)
+Check RPKI validity for a given prefix-ASN pair.
+We use RIPE NCC's [routinator instance](https://rpki-validator.ripe.net)
 as the data source.
 
 ```text
@@ -445,7 +446,7 @@ using [`radar-rs`](https://github.com/bgpkit/radar-rs) crate.
 
 Using this command requires setting up the `CF_API_TOKEN` environment variable. See
 the [Cloudflare Radar API getting started guide](https://developers.cloudflare.com/radar/get-started/first-request/) for
-detailed steps on obtaining a API token.
+detailed steps on getting an API token.
 
 #### `monocle radar stats`: routing statistics
 
@@ -563,6 +564,71 @@ Lookup RPKI invalid (with flag `--rpki-status invalid`) prefixes originated by a
 └─────────────────────┴────────┴─────────┴──────────────┘
 
 Data generated at 2023-07-24T16:00:00 UTC.
+```
+
+### `monocle ip`
+
+Retrieve information for the current IP of the machine or any specified IP address.
+The information includes location,
+network (ASN, network name) and the covering IP prefix of the given IP address.
+
+Get information for the machine's public IP address:
+
+```text
+➜  ~ monocle ip
++----------+--------------------------+
+| ip       | 104.48.0.0               |
++----------+--------------------------+
+| location | US                       |
++----------+---------+----------------+
+| network  | asn     | 7018           |
+|          +---------+----------------+
+|          | country | US             |
+|          +---------+----------------+
+|          | name    | AT&T US - 7018 |
+|          +---------+----------------+
+|          | prefix  | 104.48.0.0/12  |
+|          +---------+----------------+
+|          | rpki    | valid          |
++----------+---------+----------------+
+```
+
+Look up IP and network information for a given IP:
+
+```text
+➜  ~ monocle ip 1.1.1.1
++----------+----------------------+
+| ip       | 1.1.1.1              |
++----------+----------------------+
+| location | US                   |
++----------+---------+------------+
+| network  | asn     | 13335      |
+|          +---------+------------+
+|          | country | US         |
+|          +---------+------------+
+|          | name    | Cloudflare |
+|          +---------+------------+
+|          | prefix  | 1.1.1.0/24 |
+|          +---------+------------+
+|          | rpki    | valid      |
++----------+---------+------------+
+```
+
+Displaying the information in JSON format:
+
+```text
+➜  ~ monocle ip 1.1.1.1 --json
+{
+  "ip": "1.1.1.1",
+  "location": "US",
+  "network": {
+    "asn": 13335,
+    "country": "US",
+    "name": "Cloudflare",
+    "prefix": "1.1.1.0/24",
+    "rpki": "valid"
+  }
+}
 ```
 
 ## Built with ❤️ by BGPKIT Team

--- a/src/bin/monocle.rs
+++ b/src/bin/monocle.rs
@@ -32,7 +32,7 @@ struct Cli {
     config: Option<String>,
 
     /// Print debug information
-    #[clap(long)]
+    #[clap(long, global = true)]
     debug: bool,
 
     #[clap(subcommand)]
@@ -84,20 +84,17 @@ struct ParseFilters {
 
 #[derive(Args, Debug)]
 struct SearchFilters {
-    /*
-    REQUIRED ARGUMENTS
-     */
     /// Filter by start unix timestamp inclusive
     #[clap(short = 't', long)]
-    start_ts: String,
+    start_ts: Option<String>,
 
     /// Filter by end unix timestamp inclusive
     #[clap(short = 'T', long)]
-    end_ts: String,
+    end_ts: Option<String>,
 
-    /*
-    OPTIONAL ARGUMENTS
-     */
+    #[clap(short = 'd', long)]
+    duration: Option<String>,
+
     /// Filter by collector, e.g. rrc00 or route-views2
     #[clap(short = 'c', long)]
     collector: Option<String>,
@@ -142,12 +139,12 @@ struct SearchFilters {
 impl Validate for ParseFilters {
     fn validate(&self) -> Result<()> {
         if let Some(ts) = &self.start_ts {
-            if let Err(_) = dateparser::parse(ts) {
+            if string_to_time(ts.as_str()).is_err() {
                 return Err(anyhow!("start-ts is not a valid time string: {}", ts));
             }
         }
         if let Some(ts) = &self.end_ts {
-            if let Err(_) = dateparser::parse(ts) {
+            if string_to_time(ts.as_str()).is_err() {
                 return Err(anyhow!("end-ts is not a valid time string: {}", ts));
             }
         }
@@ -155,20 +152,71 @@ impl Validate for ParseFilters {
     }
 }
 
+impl SearchFilters {
+    fn parse_start_end_strings(&self) -> Result<(i64, i64)> {
+        let mut start_ts = None;
+        let mut end_ts = None;
+        if let Some(ts) = &self.start_ts {
+            match string_to_time(ts.as_str()) {
+                Ok(t) => start_ts = Some(t),
+                Err(_) => return Err(anyhow!("start-ts is not a valid time string: {}", ts)),
+            }
+        }
+        if let Some(ts) = &self.end_ts {
+            match string_to_time(ts.as_str()) {
+                Ok(t) => end_ts = Some(t),
+                Err(_) => return Err(anyhow!("end-ts is not a valid time string: {}", ts)),
+            }
+        }
+
+        match (&self.start_ts, &self.end_ts, &self.duration) {
+            (Some(_), Some(_), Some(_)) => {
+                return Err(anyhow!(
+                    "cannot specify start_ts, end_ts, and duration all at the same time"
+                ))
+            }
+            (Some(_), None, None) | (None, Some(_), None) => {
+                // only one start_ts or end_ts specified
+                return Err(anyhow!(
+                    "must specify two from: start_ts, end_ts and duration"
+                ));
+            }
+            (None, None, _) => {
+                return Err(anyhow!(
+                    "must specify two from: start_ts, end_ts and duration"
+                ));
+            }
+            _ => {}
+        }
+        if let Some(duration) = &self.duration {
+            // this case is duration + start_ts OR end_ts
+            let duration = match humantime::parse_duration(duration) {
+                Ok(d) => d,
+                Err(_) => {
+                    return Err(anyhow!(
+                        "duration is not a valid time duration string: {}",
+                        duration
+                    ))
+                }
+            };
+
+            if let Some(ts) = start_ts {
+                return Ok((ts.timestamp(), (ts + duration).timestamp()));
+            }
+            if let Some(ts) = end_ts {
+                return Ok(((ts - duration).timestamp(), ts.timestamp()));
+            }
+        } else {
+            // this case is start_ts AND end_ts
+            return Ok((start_ts.unwrap().timestamp(), end_ts.unwrap().timestamp()));
+        }
+
+        Err(anyhow!("unexpected time-string parsing result"))
+    }
+}
 impl Validate for SearchFilters {
     fn validate(&self) -> Result<()> {
-        if let Err(_) = dateparser::parse(&self.start_ts) {
-            return Err(anyhow!(
-                "start-ts is not a valid time string: {}",
-                &self.start_ts
-            ));
-        }
-        if let Err(_) = dateparser::parse(&self.end_ts) {
-            return Err(anyhow!(
-                "end-ts is not a valid time string: {}",
-                &self.end_ts
-            ));
-        }
+        let _ = self.parse_start_end_strings()?;
         Ok(())
     }
 }
@@ -414,7 +462,7 @@ fn main() {
             filters,
         } => {
             if let Err(e) = filters.validate() {
-                eprintln!("{e}");
+                eprintln!("ERROR: {e}");
                 return;
             }
 
@@ -443,7 +491,7 @@ fn main() {
                         let output_str = elem_to_string(&elem, json, pretty, "");
                         if let Err(e) = writeln!(stdout, "{}", &output_str) {
                             if e.kind() != std::io::ErrorKind::BrokenPipe {
-                                eprintln!("{e}");
+                                eprintln!("ERROR: {e}");
                             }
                             std::process::exit(1);
                         }
@@ -456,7 +504,7 @@ fn main() {
                     let mut writer = match oneio::get_writer(&path) {
                         Ok(w) => w,
                         Err(e) => {
-                            eprintln!("{e}");
+                            eprintln!("ERROR: {e}");
                             std::process::exit(1);
                         }
                     };
@@ -481,7 +529,7 @@ fn main() {
             filters,
         } => {
             if let Err(e) = filters.validate() {
-                eprintln!("{e}");
+                eprintln!("ERROR: {e}");
                 return;
             }
 
@@ -493,14 +541,12 @@ fn main() {
             let mrt_path = mrt_path.map(|p| p.to_str().unwrap().to_string());
             let show_progress = sqlite_db.is_some() || mrt_path.is_some();
 
-            let ts_start = string_to_time(filters.start_ts.as_str())
-                .unwrap()
-                .to_string();
-            let ts_end = string_to_time(filters.end_ts.as_str()).unwrap().to_string();
+            // it's fine to unwrap as the filters.validate() function has already checked for issues
+            let (ts_start, ts_end) = filters.parse_start_end_strings().unwrap();
 
             let mut broker = bgpkit_broker::BgpkitBroker::new()
-                .ts_start(ts_start.as_str())
-                .ts_end(ts_end.as_str())
+                .ts_start(ts_start)
+                .ts_end(ts_end)
                 .data_type("update")
                 .page_size(1000);
 
@@ -642,8 +688,9 @@ fn main() {
                         &filters.peer_ip,
                         &filters.peer_asn,
                         &filters.elem_type,
-                        &Some(filters.start_ts.clone()),
-                        &Some(filters.end_ts.clone()),
+                        // use the parsed new start and end ts
+                        &Some(ts_start.to_string()),
+                        &Some(ts_end.to_string()),
                         &filters.as_path,
                     )
                     .unwrap();
@@ -694,7 +741,7 @@ fn main() {
                 (false, true) => SearchType::AsnOnly,
                 (false, false) => SearchType::Guess,
                 (true, true) => {
-                    eprintln!("name-only and asn-only cannot be both true");
+                    eprintln!("ERROR: name-only and asn-only cannot be both true");
                     return;
                 }
             };
@@ -772,7 +819,7 @@ fn main() {
         }
         Commands::Time { time, simple } => {
             let timestring_res = match simple {
-                true => convert_time_string(&time),
+                true => parse_time_string_to_rfc3339(&time),
                 false => time_to_table(&time),
             };
             match timestring_res {
@@ -780,7 +827,7 @@ fn main() {
                     println!("{t}")
                 }
                 Err(e) => {
-                    eprintln!("{e}")
+                    eprintln!("ERROR: {e}")
                 }
             };
         }
@@ -797,7 +844,7 @@ fn main() {
                 let res = match read_roa(file_path.to_str().unwrap()) {
                     Ok(r) => r,
                     Err(e) => {
-                        eprintln!("unable to read ROA file: {}", e);
+                        eprintln!("ERROR: unable to read ROA file: {}", e);
                         return;
                     }
                 };
@@ -810,7 +857,7 @@ fn main() {
                 let res = match read_aspa(file_path.to_str().unwrap()) {
                     Ok(r) => r,
                     Err(e) => {
-                        eprintln!("unable to read ASPA file: {}", e);
+                        eprintln!("ERROR: unable to read ASPA file: {}", e);
                         return;
                     }
                 };
@@ -828,7 +875,7 @@ fn main() {
                 let (validity, roas) = match validate(asn, prefix.as_str()) {
                     Ok((v1, v2)) => (v1, v2),
                     Err(e) => {
-                        eprintln!("unable to check RPKI validity: {}", e);
+                        eprintln!("ERROR: unable to check RPKI validity: {}", e);
                         return;
                     }
                 };
@@ -852,7 +899,10 @@ fn main() {
                     Err(_) => match resource.parse::<IpNet>() {
                         Ok(prefix) => list_by_prefix(&prefix).unwrap(),
                         Err(_) => {
-                            eprintln!("list resource not an AS number or a prefix: {}", resource);
+                            eprintln!(
+                                "ERROR: list resource not an AS number or a prefix: {}",
+                                resource
+                            );
                             return;
                         }
                     },
@@ -893,7 +943,7 @@ fn main() {
                     let res = match client.get_bgp_routing_stats(asn, country.clone()) {
                         Ok(res) => res,
                         Err(e) => {
-                            eprintln!("unable to get routing stats: {}", e);
+                            eprintln!("ERROR: unable to get routing stats: {}", e);
                             return;
                         }
                     };
@@ -903,7 +953,7 @@ fn main() {
                         (Some(c), None) => c,
                         (None, Some(asn)) => format!("as{}", asn),
                         (Some(_), Some(_)) => {
-                            eprintln!("cannot specify both country and ASN");
+                            eprintln!("ERROR: cannot specify both country and ASN");
                             return;
                         }
                     };
@@ -1007,7 +1057,7 @@ fn main() {
                         match rpki_status.to_lowercase().as_str() {
                             "valid" | "invalid" | "unknown" => Some(rpki_status),
                             _ => {
-                                eprintln!("invalid rpki status: {}", rpki_status);
+                                eprintln!("ERROR: invalid rpki status: {}", rpki_status);
                                 return;
                             }
                         }
@@ -1018,7 +1068,7 @@ fn main() {
                     let res = match client.get_bgp_prefix_origins(asn, prefix, rpki) {
                         Ok(res) => res,
                         Err(e) => {
-                            eprintln!("unable to get prefix origins: {}", e);
+                            eprintln!("ERROR: unable to get prefix origins: {}", e);
                             return;
                         }
                     };
@@ -1083,7 +1133,7 @@ fn main() {
                 }
             }
             Err(e) => {
-                eprintln!("unable to get ip information: {e}");
+                eprintln!("ERROR: unable to get ip information: {e}");
             }
         },
     }

--- a/src/bin/monocle.rs
+++ b/src/bin/monocle.rs
@@ -8,7 +8,6 @@ use std::thread;
 use anyhow::{anyhow, Result};
 use bgpkit_parser::encoder::MrtUpdatesEncoder;
 use bgpkit_parser::BgpElem;
-use chrono::DateTime;
 use clap::{Args, Parser, Subcommand};
 use ipnet::IpNet;
 use json_to_table::json_to_table;
@@ -143,47 +142,33 @@ struct SearchFilters {
 impl Validate for ParseFilters {
     fn validate(&self) -> Result<()> {
         if let Some(ts) = &self.start_ts {
-            if !(ts.parse::<f64>().is_ok() || DateTime::parse_from_rfc3339(ts).is_ok()) {
-                // not a number or a rfc3339 string
-                return Err(anyhow!(
-                    "start-ts must be either a unix-timestamp or a RFC3339-compliant string"
-                ));
+            if let Err(_) = dateparser::parse(ts) {
+                return Err(anyhow!("start-ts is not a valid time string: {}", ts));
             }
         }
         if let Some(ts) = &self.end_ts {
-            if !(ts.parse::<f64>().is_ok() || DateTime::parse_from_rfc3339(ts).is_ok()) {
-                // not a number or a rfc3339 string
-                return Err(anyhow!(
-                    "end-ts must be either a unix-timestamp or a RFC3339-compliant string"
-                ));
+            if let Err(_) = dateparser::parse(ts) {
+                return Err(anyhow!("end-ts is not a valid time string: {}", ts));
             }
         }
-
         Ok(())
     }
 }
 
 impl Validate for SearchFilters {
     fn validate(&self) -> Result<()> {
-        if !(self.start_ts.as_str().parse::<f64>().is_ok()
-            || DateTime::parse_from_rfc3339(self.start_ts.as_str()).is_ok())
-        {
-            // not a number or a rfc3339 string
+        if let Err(_) = dateparser::parse(&self.start_ts) {
             return Err(anyhow!(
-                "start-ts must be either a unix-timestamp or a RFC3339-compliant string: {}",
-                self.start_ts
+                "start-ts is not a valid time string: {}",
+                &self.start_ts
             ));
         }
-        if !(self.end_ts.as_str().parse::<f64>().is_ok()
-            || DateTime::parse_from_rfc3339(self.end_ts.as_str()).is_ok())
-        {
-            // not a number or a rfc3339 string
+        if let Err(_) = dateparser::parse(&self.end_ts) {
             return Err(anyhow!(
-                "end-ts must be either a unix-timestamp or a RFC3339-compliant string: {}",
-                self.end_ts
+                "end-ts is not a valid time string: {}",
+                &self.end_ts
             ));
         }
-
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,14 +33,10 @@ pub fn parser_with_filters(
     let mut parser = BgpkitParser::new(file_path).unwrap().disable_warnings();
 
     if let Some(v) = as_path {
-        parser = parser
-            .add_filter("as_path", v.to_string().as_str())
-            .unwrap();
+        parser = parser.add_filter("as_path", v.to_string().as_str())?;
     }
     if let Some(v) = origin_asn {
-        parser = parser
-            .add_filter("origin_asn", v.to_string().as_str())
-            .unwrap();
+        parser = parser.add_filter("origin_asn", v.to_string().as_str())?;
     }
     if let Some(v) = prefix {
         let filter_type = match (include_super, include_sub) {
@@ -49,31 +45,25 @@ pub fn parser_with_filters(
             (false, true) => "prefix_sub",
             (true, true) => "prefix_super_sub",
         };
-        parser = parser.add_filter(filter_type, v.as_str()).unwrap();
+        parser = parser.add_filter(filter_type, v.as_str())?;
     }
     if !peer_ip.is_empty() {
         let v = peer_ip.iter().map(|p| p.to_string()).join(",");
-        parser = parser.add_filter("peer_ips", v.as_str()).unwrap();
+        parser = parser.add_filter("peer_ips", v.as_str())?;
     }
     if let Some(v) = peer_asn {
-        parser = parser
-            .add_filter("peer_asn", v.to_string().as_str())
-            .unwrap();
+        parser = parser.add_filter("peer_asn", v.to_string().as_str())?;
     }
     if let Some(v) = elem_type {
-        parser = parser.add_filter("type", v.to_string().as_str()).unwrap();
+        parser = parser.add_filter("type", v.to_string().as_str())?;
     }
     if let Some(v) = start_ts {
-        let ts = string_to_time(v.as_str())?;
-        parser = parser
-            .add_filter("start_ts", ts.to_string().as_str())
-            .unwrap();
+        let ts = string_to_time(v.as_str())?.timestamp();
+        parser = parser.add_filter("start_ts", ts.to_string().as_str())?;
     }
     if let Some(v) = end_ts {
-        let ts = string_to_time(v.as_str())?;
-        parser = parser
-            .add_filter("end_ts", ts.to_string().as_str())
-            .unwrap();
+        let ts = string_to_time(v.as_str())?.timestamp();
+        parser = parser.add_filter("end_ts", ts.to_string().as_str())?;
     }
     Ok(parser)
 }
@@ -85,13 +75,13 @@ struct BgpTime {
     human: String,
 }
 
-pub fn string_to_time(time_string: &str) -> Result<i64> {
+pub fn string_to_time(time_string: &str) -> Result<DateTime<Utc>> {
     let ts = match dateparser::parse_with(
         time_string,
         &Utc,
         chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
     ) {
-        Ok(ts) => ts.timestamp(),
+        Ok(ts) => ts,
         Err(_) => {
             return Err(anyhow!(
                 "Input time must be either Unix timestamp or time string compliant with RFC3339"
@@ -102,26 +92,18 @@ pub fn string_to_time(time_string: &str) -> Result<i64> {
     Ok(ts)
 }
 
-pub fn convert_time_string(time_vec: &[String]) -> Result<String> {
-    let time_strings = match time_vec.len() {
-        0 => vec![Utc::now().to_rfc3339()],
-        _ => {
-            // check if ts is a valid Unix timestamp
-            time_vec
-                .iter()
-                .map(|ts| {
-                    match dateparser::parse_with(
-                        ts,
-                        &Utc,
-                        chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
-                    ) {
-                        Ok(ts) => ts.to_rfc3339(),
-                        Err(_) => "".to_string(),
-                    }
-                })
-                .collect()
+pub fn parse_time_string_to_rfc3339(time_vec: &[String]) -> Result<String> {
+    let mut time_strings = vec![];
+    if time_vec.is_empty() {
+        time_strings.push(Utc::now().to_rfc3339())
+    } else {
+        for ts in time_vec {
+            match string_to_time(ts) {
+                Ok(ts) => time_strings.push(ts.to_rfc3339()),
+                Err(_) => return Err(anyhow!("unable to parse timestring: {}", ts)),
+            }
         }
-    };
+    }
 
     Ok(time_strings.join("\n"))
 }
@@ -132,8 +114,8 @@ pub fn time_to_table(time_vec: &[String]) -> Result<String> {
         true => vec![now_ts],
         false => time_vec
             .iter()
-            .map(|ts| string_to_time(ts.as_str()).unwrap_or_default())
-            .collect(),
+            .map(|ts| string_to_time(ts.as_str()).map(|dt| dt.timestamp()))
+            .collect::<Result<Vec<_>>>()?,
     };
 
     let bgptime_vec = ts_vec
@@ -153,4 +135,48 @@ pub fn time_to_table(time_vec: &[String]) -> Result<String> {
         .collect::<Vec<BgpTime>>();
 
     Ok(Table::new(bgptime_vec).with(Style::rounded()).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_to_time() {
+        use chrono::TimeZone;
+
+        // Test with a valid Unix timestamp
+        let unix_ts = "1697043600"; // Example timestamp
+        let result = string_to_time(unix_ts);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Utc.timestamp_opt(1697043600, 0).unwrap());
+
+        // Test with a valid RFC3339 string
+        let rfc3339_str = "2023-10-11T00:00:00Z";
+        let result = string_to_time(rfc3339_str);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Utc.timestamp_opt(1696982400, 0).unwrap());
+
+        // Test with an incorrect date string
+        let invalid_date = "not-a-date";
+        let result = string_to_time(invalid_date);
+        assert!(result.is_err());
+
+        // Test with an empty string
+        let empty_string = "";
+        let result = string_to_time(empty_string);
+        assert!(result.is_err());
+
+        // Test with incomplete RFC3339 string
+        let incomplete_rfc3339 = "2023-10-11T";
+        let result = string_to_time(incomplete_rfc3339);
+        assert!(result.is_err());
+
+        // Test with a human-readable date string allowed by `dateparser`
+        let human_readable = "October 11, 2023";
+        let result = string_to_time(human_readable);
+        assert!(result.is_ok());
+        let expected_time = Utc.with_ymd_and_hms(2023, 10, 11, 0, 0, 0).unwrap();
+        assert_eq!(result.unwrap(), expected_time);
+    }
 }


### PR DESCRIPTION
### Description
This pull request introduces a feature that enhances the parsing of dates within the `time` command. It incorporates the [`dateparser`][dateparser] crate, providing support for more flexible date formats.

#### Changes:
- Utilized [`dateparser`][dateparser] for natural date strings like "May 6 at 9:24 PM" or "2019-11-29 08:08-08".
- Allowing specify a `duration` like `1h` or `"2 hours"` to replace `--start-ts` or `--end-ts`.
- Adjusted `time` command to handle broader input cases.
- Updated documentation for the `time` subcommand.

#### Dependencies:
- Added `dateparser` v0.2.1 for flexible date/time recognition and parsing.

#### Related issue:

#62 #61 #53 

[dateparser]: https://github.com/waltzofpearls/dateparser