### PR TITLE
add pfx2as subcommand for bulk prefix-to-as lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet-trie"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd839300aeeb010677522802bd17878847da94e4871ebe2653aa8087c5385af"
+dependencies = [
+ "ipnet",
+ "prefix-trie",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1500,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "ipnet",
+ "ipnet-trie",
  "itertools",
  "json_to_table",
  "oneio",
@@ -1584,6 +1595,8 @@ dependencies = [
  "flate2",
  "reqwest 0.12.12",
  "rust-s3",
+ "serde",
+ "serde_json",
  "suppaftp",
  "thiserror 1.0.69",
 ]
@@ -1737,6 +1750,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fe48f29e6e6fcf123d0d03d63028dbe4c4a738023d35d525df4882f4929418"
+dependencies = [
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,10 @@ dotenvy = "0.15"
 humantime = "2.1"
 indicatif = "0.17.0" # progress bar
 ipnet = { version = "2.10", features = ["json"] }
+ipnet-trie = "0.2.0"
 itertools = "0.14"
 json_to_table = "0.10.0"
-oneio = { version = "0.17.0", default-features = false, features = ["remote", "gz", "bz"] }
+oneio = { version = "0.17.0", default-features = false, features = ["remote", "gz", "bz", "json"] }
 radar-rs = "0.1.0"
 rayon = "1.8"
 regex = "1.10"

--- a/src/bin/monocle.rs
+++ b/src/bin/monocle.rs
@@ -14,7 +14,7 @@ use monocle::*;
 use radar_rs::RadarClient;
 use rayon::prelude::*;
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use tabled::settings::{Merge, Style};
 use tabled::{Table, Tabled};
 use tracing::{info, Level};
@@ -974,8 +974,18 @@ fn main() {
             }
 
             // display
-            for pair in prefix_origin_pairs {
-                println!("{},{}", pair.0, pair.1);
+            if json {
+                // map prefix_origin_pairs to a vector of JSON objects each with a
+                // "prefix" and "origin" field
+                let data = prefix_origin_pairs
+                    .iter()
+                    .map(|(p, o)| json!({"prefix": p.to_string(), "origin": *o}))
+                    .collect::<Vec<Value>>();
+                serde_json::to_writer_pretty(std::io::stdout(), &data).unwrap();
+            } else {
+                for pair in prefix_origin_pairs {
+                    println!("{},{}", pair.0, pair.1);
+                }
             }
         }
     }

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -1,11 +1,13 @@
 mod as2org;
 mod country;
 mod ip;
+mod pfx2as;
 mod radar;
 mod rpki;
 
 pub use crate::datasets::as2org::*;
 pub use crate::datasets::country::*;
 pub use crate::datasets::ip::*;
+pub use crate::datasets::pfx2as::*;
 pub use crate::datasets::radar::*;
 pub use crate::datasets::rpki::*;

--- a/src/datasets/pfx2as.rs
+++ b/src/datasets/pfx2as.rs
@@ -1,0 +1,122 @@
+//! Prefix-to-ASN mapping tool
+
+use anyhow::Result;
+use ipnet::IpNet;
+use ipnet_trie::IpnetTrie;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// A data structure for performing prefix-to-ASN mappings.
+///
+/// The `Pfx2as` struct uses an internal trie to organize IP prefixes
+/// and their associated Autonomous System Numbers (ASNs). It provides
+/// functionality for loading prefix-to-ASN mappings from a source file and
+/// methods for performing exact and longest prefix matches.
+///
+/// # Features
+/// - Load prefix-to-ASN mappings from a JSON data source (`pfx2as-latest.json.bz2`).
+/// - Perform exact match lookups with the `lookup_exact` method.
+/// - Perform longest prefix match (LPM) lookups with the `lookup_longest` method.
+pub struct Pfx2as {
+    trie: IpnetTrie<HashSet<u32>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Pfx2asEntry {
+    asn: u32,
+    count: u32,
+    prefix: String,
+}
+
+const BGPKIT_PFX2AS_URL: &str = "https://data.bgpkit.com/pfx2as/pfx2as-latest.json.bz2";
+
+impl Pfx2as {
+    pub fn new(path_opt: Option<String>) -> Result<Pfx2as> {
+        let path = path_opt.unwrap_or(BGPKIT_PFX2AS_URL.to_string());
+        let entries = oneio::read_json_struct::<Vec<Pfx2asEntry>>(&path)?;
+
+        let mut trie = IpnetTrie::<HashSet<u32>>::new();
+        for entry in entries {
+            if let Ok(prefix) = entry.prefix.parse::<IpNet>() {
+                match trie.exact_match_mut(prefix) {
+                    None => {
+                        let set = HashSet::from_iter([entry.asn]);
+                        trie.insert(prefix, set);
+                    }
+                    Some(s) => {
+                        s.insert(entry.asn);
+                    }
+                }
+            }
+        }
+        Ok(Pfx2as { trie })
+    }
+
+    /// Look up exact matches for the given IP prefix.
+    ///
+    /// This method searches for prefixes in the trie that exactly match the given `prefix`.
+    /// If a match is found, it returns a vector containing ASNs associated with the matching prefix.
+    /// If no match is found, an empty vector is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - An `IpNet` object representing the IP prefix to be matched.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u32>` containing ASNs associated with the matching prefix.
+    /// If no exact matching prefix is found, the returned vector will be empty.
+    pub fn lookup_exact(&self, prefix: IpNet) -> Vec<u32> {
+        match self.trie.exact_match(prefix) {
+            None => {
+                vec![]
+            }
+            Some(s) => s.iter().cloned().collect(),
+        }
+    }
+
+    /// Perform the longest prefix match (LPM) for the given IP prefix.
+    ///
+    /// This method finds the most specific prefix in the trie that matches
+    /// the given IP prefix. It returns a list of ASNs associated with the
+    /// longest matching prefix, if any exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - An `IpNet` object representing the IP prefix to be matched.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u32>` containing ASNs associated with the longest matching prefix.
+    /// If no matching prefix is found, the returned vector will be empty.
+    pub fn lookup_longest(&self, prefix: IpNet) -> Vec<u32> {
+        match self.trie.longest_match(&prefix) {
+            None => {
+                vec![]
+            }
+            Some((_p, s)) => s.iter().cloned().collect(),
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_lookup() {
+        let pfx2as = Pfx2as::new(None).unwrap();
+        assert_eq!(
+            pfx2as.lookup_exact(IpNet::from_str("1.1.1.0/24").unwrap()),
+            vec![13335]
+        );
+        assert_eq!(
+            pfx2as.lookup_exact(IpNet::from_str("2620:aa:a000::/48").unwrap()),
+            vec![400644]
+        );
+        assert_eq!(
+            pfx2as.lookup_longest(IpNet::from_str("1.1.1.1/32").unwrap()),
+            vec![13335]
+        );
+    }
+}

--- a/src/datasets/pfx2as.rs
+++ b/src/datasets/pfx2as.rs
@@ -98,25 +98,3 @@ impl Pfx2as {
         }
     }
 }
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_lookup() {
-        let pfx2as = Pfx2as::new(None).unwrap();
-        assert_eq!(
-            pfx2as.lookup_exact(IpNet::from_str("1.1.1.0/24").unwrap()),
-            vec![13335]
-        );
-        assert_eq!(
-            pfx2as.lookup_exact(IpNet::from_str("2620:aa:a000::/48").unwrap()),
-            vec![400644]
-        );
-        assert_eq!(
-            pfx2as.lookup_longest(IpNet::from_str("1.1.1.1/32").unwrap()),
-            vec![13335]
-        );
-    }
-}


### PR DESCRIPTION
### Usage

```
Bulk prefix-to-AS mapping lookup with the pre-generated data file

Usage: monocle pfx2as [OPTIONS] <INPUT>...

Arguments:
  <INPUT>...  IP prefixes or prefix files (one prefix per line)

Options:
      --data-file-path <DATA_FILE_PATH>
          Prefix-to-AS mapping data file location [default: https://data.bgpkit.com/pfx2as/pfx2as-latest.json.bz2]
      --debug
          Print debug information
  -e, --exact-match
          Only matching exact prefixes. By default, it does longest-prefix matching
      --json
          Output as JSON objects
  -h, --help
          Print help
  -V, --version
          Print version
```

```
➜  cargo run --release -- pfx2as 1.1.1.0/24 8.8.8.0/24 --json
[
  {
    "origin": 13335,
    "prefix": "1.1.1.0/24"
  },
  {
    "origin": 15169,
    "prefix": "8.8.8.0/24"
  }
]
```