### PR TITLE
Handle null IP API fields

### DIFF
--- a/src/datasets/ip.rs
+++ b/src/datasets/ip.rs
@@ -20,14 +20,14 @@ pub struct AsnRouteInfo {
     pub prefix: IpNet,
     pub rpki: RpkiValidationState,
     pub name: String,
-    pub country: String,
+    pub country: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpInfo {
     pub ip: String,
     #[serde(rename(serialize = "location"))]
-    pub country: String,
+    pub country: Option<String>,
     #[serde(rename(serialize = "network"))]
     pub asn: Option<AsnRouteInfo>,
 }


### PR DESCRIPTION
bugfix
```
cargo run -- ip 2408:875c:5000:b:3:0:0:4e

ERROR: unable to get ip information: json: invalid type: null, expected a string at line 1 column 45
```