### PR TITLE
feat: add --order-by and --order parameters to parse and search commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased changes
+
+### New Features
+
+* Added `--fields` (`-f`) option to `parse` and `search` commands for selecting output fields ([#99](https://github.com/bgpkit/monocle/issues/99), [#101](https://github.com/bgpkit/monocle/pull/101))
+  * Choose which columns to display with comma-separated field names
+  * Available fields: `type`, `timestamp`, `peer_ip`, `peer_asn`, `prefix`, `as_path`, `origin`, `next_hop`, `local_pref`, `med`, `communities`, `atomic`, `aggr_asn`, `aggr_ip`, `collector`
+  * Parse command defaults exclude `collector` field (not applicable)
+  * Search command defaults include `collector` field
+  * Example: `monocle search -t 2024-01-01 -d 1h -f prefix,as_path,collector`
+
+* Added proper table formatting with borders using `tabled` crate for `--format table` ([#99](https://github.com/bgpkit/monocle/issues/99), [#101](https://github.com/bgpkit/monocle/pull/101))
+  * Table output now uses rounded borders instead of tab-separated values
+  * Markdown format includes proper header row with separator
+
+* Added `--order-by` and `--order` parameters to `parse` and `search` commands ([#98](https://github.com/bgpkit/monocle/issues/98))
+  * Sort output by: `timestamp`, `prefix`, `peer_ip`, `peer_asn`, `as_path`, or `next_hop`
+  * Direction: `asc` (ascending, default) or `desc` (descending)
+  * When ordering is specified, output is buffered and sorted before display
+  * Example: `monocle parse file.mrt --order-by timestamp --order asc`
+  * Example: `monocle search -t 2024-01-01 -d 1h -p 1.1.1.0/24 --order-by timestamp --order desc`
+
 ## v1.0.2 - 2025-12-18
 
 ### New Features


### PR DESCRIPTION
## Summary

This PR adds sorting capability to the `parse` and `search` commands, allowing users to output results in a specified order (e.g., chronological or reverse chronological).

Closes #98

## Changes

- Added `--order-by` option to specify the field to sort by
- Added `--order` option to specify sort direction (asc/desc, default: asc)
- When ordering is requested, output is buffered and sorted before display
- Updated CHANGELOG.md with unreleased changes

## Available Order-By Fields

- `timestamp` - Order by timestamp (default)
- `prefix` - Order by network prefix
- `peer_ip` - Order by peer IP address
- `peer_asn` - Order by peer AS number
- `as_path` - Order by AS path (string comparison)
- `next_hop` - Order by next hop IP address

## Examples

```bash
# Parse with chronological ordering (ascending)
monocle parse file.mrt --order-by timestamp --order asc

# Parse with reverse chronological ordering (descending)
monocle parse file.mrt --order-by timestamp --order desc

# Search with ordering
monocle search -t 2024-01-01 -d 1h -p 1.1.1.0/24 --order-by timestamp --order desc

# Order by peer ASN
monocle parse file.mrt --order-by peer_asn --order asc
```

## Notes

- Field names use underscores (e.g., `peer_ip`, `as_path`) to match the output field names
- When `--order-by` is specified, all output is buffered before display (similar to table format behavior)
- Without `--order-by`, streaming output behavior is preserved for better performance with large datasets