### PR TITLE
feat: add --time-format parameter for parse and search commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
   * Example: `-o '!13335,!15169'` excludes elements from AS13335 AND AS15169
   * Note: Cannot mix positive and negative values in the same filter
 * Added validation for ASN format, prefix CIDR notation, and negation consistency
+* **`--time-format`**: Added timestamp output format option to `parse` and `search` commands
+  * `--time-format unix` (default): Output timestamps as Unix epoch (integer/float)
+  * `--time-format rfc3339`: Output timestamps in ISO 8601/RFC3339 format (e.g., `2023-10-11T17:00:00+00:00`)
+  * Applies to non-JSON output formats (table, psv, markdown)
+  * JSON output always uses numeric Unix timestamps for backward compatibility
+  * Example: `monocle parse file.mrt --time-format rfc3339`
+  * Example: `monocle search -t 2024-01-01 -d 1h -p 1.1.1.0/24 --time-format rfc3339`
 
 ### Code Improvements
 


### PR DESCRIPTION
## Summary

Add `--time-format` parameter to `monocle parse` and `monocle search` commands to control how timestamps are displayed in output.

## Features

- **`--time-format unix`** (default): Output timestamps as Unix epoch (integer or float)
  - Example: `1697043600` or `1697043600.5`
- **`--time-format rfc3339`**: Output timestamps in ISO 8601/RFC3339 format  
  - Example: `2023-10-11T17:00:00+00:00`

## Usage Examples
Together with `--format table` and `--fields timestamp,prefix,as_path`, the updated command results can look much cleaner:

```
monocle search -t 2024-01-01 -d 1s -c route-views3 -p 140.99.244.0/23,201.87.136.0/24 --time-format rfc3339 --format table --fields timestamp,prefix,as_path`
╭─────────────────────────────────────┬─────────────────┬──────────────────────────────────────────────╮
│ timestamp                           │ prefix          │ as_path                                      │
├─────────────────────────────────────┼─────────────────┼──────────────────────────────────────────────┤
│ 2024-01-01T00:00:00.177294969+00:00 │ 140.99.244.0/23 │ 209 3356 3223 20068                          │
│ 2024-01-01T00:00:00.563082933+00:00 │ 140.99.244.0/23 │ 23367 1299 3356 3223 20068                   │
│ 2024-01-01T00:00:00.617777109+00:00 │ 201.87.136.0/24 │ 6939 52320 28598 265303 265303 265303 265303 │
╰─────────────────────────────────────┴─────────────────┴──────────────────────────────────────────────╯
```

## Backward Compatibility

- **Default behavior unchanged**: `--time-format unix` is the default, maintaining existing output format
- **JSON output unaffected**: JSON output always uses numeric Unix timestamps regardless of `--time-format` setting, ensuring backward compatibility for scripts that parse JSON output
- **Non-breaking**: All existing command invocations continue to work identically

## Implementation Details

- Added `TimestampFormat` enum to `src/lens/utils.rs` with variants `Unix` and `Rfc3339`
- Updated `elem_format.rs` to support timestamp formatting via `get_field_value_with_time_format()`
- Added `--time-format` CLI argument to both `parse.rs` and `search.rs` commands
- JSON output functions (`build_json_object`) continue to use `json!(elem.timestamp)` to preserve numeric output