### PR TITLE
feat: add --cache-dir parameter for search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this project will be documented in this file.
   * Cached files are reused on subsequent runs, avoiding redundant downloads
   * Uses `.partial` extension during downloads to handle interrupted transfers
   * Cache directory access is validated upfront before processing begins
+  * **Broker query caching**: When `--cache-dir` is specified, broker API query results are cached in SQLite
+    * Cache stored at `{cache-dir}/broker-cache.sqlite3`
+    * Only queries with end time >2 hours in the past are cached (recent data may still change)
+    * Subsequent identical queries use cached results, enabling offline operation
+    * Tested: run search once, disable network, run same search again - results returned from cache
   * Example: `monocle search -t 2024-01-01 -d 1h --cache-dir /tmp/mrt-cache`
 * **Multi-value filters**: `parse` and `search` commands now support filtering by multiple values with OR logic
   * Example: `-o 13335,15169,8075` matches elements from ANY of the specified origin ASNs


### PR DESCRIPTION
## Summary

Add `--cache-dir` parameter to the `search` command for local MRT file caching and broker query caching.

## Features

### MRT File Caching
- Download MRT files to a local cache directory before parsing
- Files are cached as `{cache-dir}/{collector}/{path}` mirroring the remote structure
- Cached files are reused on subsequent runs, avoiding redundant downloads
- Uses `.partial` extension during downloads to handle interrupted transfers
- Cache directory access is validated upfront before processing begins

### Broker Query Caching
- Broker API query results are cached in SQLite at `{cache-dir}/broker-cache.sqlite3`
- Only queries with end time >2 hours in the past are cached (recent data may still change)
- Subsequent identical queries use cached results, enabling offline operation
- Cache is query-specific (based on time range, collector, project, data type)
- **Tested**: Run search once, disable network, run same search again - results returned successfully from cache

## Example

```bash
cargo run --release -- search -t 2024-01-01 -d 1h --cache-dir test-cache -c route-views3
...
tree test-cache
test-cache
├── broker-cache.sqlite3
└── route-views3
    └── bgpdata
        └── 2024.01
            └── UPDATES
                ├── updates.20240101.0000.bz2
                ├── updates.20240101.0015.bz2
                ├── updates.20240101.0030.bz2
                └── updates.20240101.0045.bz2
```

## Cache Path Examples

| URL | Cache Path |
|-----|------------|
| `https://data.ris.ripe.net/rrc00/2024.01/updates.20240101.0000.gz` | `{cache}/rrc00/2024.01/updates.20240101.0000.gz` |
| `http://archive.routeviews.org/bgpdata/2024.01/UPDATES/updates.bz2` | `{cache}/route-views2/bgpdata/2024.01/UPDATES/updates.bz2` |
| `http://archive.routeviews.org/route-views6/bgpdata/2024.01/UPDATES/updates.bz2` | `{cache}/route-views6/bgpdata/2024.01/UPDATES/updates.bz2` |

## Related issues

#29 #96 