### PR TITLE
feat: add specific reason for data refresh logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+### Code Improvements
+
+* **Data refresh logging**: CLI now shows specific reason for data refresh ("data is empty" vs "data is outdated") instead of generic "empty or outdated" message
+
 ### Breaking Changes
 
 * **ParseFilters**: Changed filter field types to support multiple values with OR logic

--- a/src/bin/commands/as2rel.rs
+++ b/src/bin/commands/as2rel.rs
@@ -198,14 +198,15 @@ pub fn run(
     let lens = As2relLens::new(&db);
 
     // Check if data needs to be initialized or updated automatically
-    if lens.needs_update() {
+    if let Some(reason) = lens.update_reason() {
         if no_refresh {
             eprintln!(
-                "[monocle] Warning: AS2rel data is empty or outdated. Results may be incomplete."
+                "[monocle] Warning: AS2rel {} Results may be incomplete.",
+                reason
             );
             eprintln!("[monocle]          Run without --no-refresh or use 'monocle config db-refresh --as2rel' to load data.");
         } else {
-            eprintln!("[monocle] AS2rel data is empty or outdated, updating now...");
+            eprintln!("[monocle] AS2rel {}, updating now...", reason);
 
             match lens.update() {
                 Ok(count) => {

--- a/src/bin/commands/pfx2as.rs
+++ b/src/bin/commands/pfx2as.rs
@@ -98,9 +98,9 @@ pub fn run(
 
     // Check if pfx2as data needs refresh
     if !no_refresh {
-        match lens.needs_refresh() {
-            Ok(true) => {
-                eprintln!("[monocle] Pfx2as data is empty or outdated, updating now...");
+        match lens.refresh_reason() {
+            Ok(Some(reason)) => {
+                eprintln!("[monocle] Pfx2as {}, updating now...", reason);
                 match lens.refresh(None) {
                     Ok(count) => {
                         eprintln!("[monocle] Pfx2as data updated: {} records loaded", count);
@@ -111,7 +111,7 @@ pub fn run(
                     }
                 }
             }
-            Ok(false) => {}
+            Ok(None) => {}
             Err(e) => {
                 eprintln!(
                     "[monocle] Warning: Could not check pfx2as data status: {}",
@@ -122,8 +122,8 @@ pub fn run(
 
         // Also ensure RPKI data is available for validation
         let rpki_lens = RpkiLens::new(&db);
-        if let Ok(true) = rpki_lens.needs_refresh() {
-            eprintln!("[monocle] RPKI data is empty or outdated, updating for validation...");
+        if let Ok(Some(reason)) = rpki_lens.refresh_reason() {
+            eprintln!("[monocle] RPKI {}, updating for validation...", reason);
             match rpki_lens.refresh() {
                 Ok((roa_count, aspa_count)) => {
                     eprintln!(

--- a/src/lens/as2rel/mod.rs
+++ b/src/lens/as2rel/mod.rs
@@ -46,6 +46,27 @@ impl<'a> As2relLens<'a> {
         self.db.needs_as2rel_update()
     }
 
+    /// Check why the data needs update, if at all
+    ///
+    /// Returns `Some(RefreshReason)` if update is needed, `None` if data is current.
+    pub fn update_reason(&self) -> Option<crate::lens::utils::RefreshReason> {
+        use crate::lens::utils::RefreshReason;
+
+        let as2rel = self.db.as2rel();
+
+        // Check if empty first
+        if as2rel.is_empty() {
+            return Some(RefreshReason::Empty);
+        }
+
+        // Check if outdated (uses should_update which checks 7-day TTL)
+        if self.db.needs_as2rel_update() {
+            return Some(RefreshReason::Outdated);
+        }
+
+        None
+    }
+
     /// Update AS2Rel data from the default URL
     pub fn update(&self) -> Result<usize> {
         self.db.update_as2rel()

--- a/src/lens/pfx2as/mod.rs
+++ b/src/lens/pfx2as/mod.rs
@@ -375,6 +375,27 @@ impl<'a> Pfx2asLens<'a> {
             .needs_refresh(crate::database::DEFAULT_PFX2AS_CACHE_TTL))
     }
 
+    /// Check why the cache needs refresh, if at all
+    ///
+    /// Returns `Some(RefreshReason)` if refresh is needed, `None` if data is current.
+    pub fn refresh_reason(&self) -> Result<Option<crate::lens::utils::RefreshReason>> {
+        use crate::lens::utils::RefreshReason;
+
+        let pfx2as = self.db.pfx2as();
+
+        // Check if empty first
+        if pfx2as.is_empty() {
+            return Ok(Some(RefreshReason::Empty));
+        }
+
+        // Check if outdated
+        if pfx2as.needs_refresh(crate::database::DEFAULT_PFX2AS_CACHE_TTL) {
+            return Ok(Some(RefreshReason::Outdated));
+        }
+
+        Ok(None)
+    }
+
     /// Get cache metadata
     pub fn get_metadata(&self) -> Result<Option<crate::database::Pfx2asCacheDbMetadata>> {
         self.db.pfx2as().get_metadata()

--- a/src/lens/rpki/mod.rs
+++ b/src/lens/rpki/mod.rs
@@ -390,6 +390,27 @@ impl<'a> RpkiLens<'a> {
             .needs_refresh(crate::database::DEFAULT_RPKI_CACHE_TTL))
     }
 
+    /// Check why the cache needs refresh, if at all
+    ///
+    /// Returns `Some(RefreshReason)` if refresh is needed, `None` if data is current.
+    pub fn refresh_reason(&self) -> Result<Option<crate::lens::utils::RefreshReason>> {
+        use crate::lens::utils::RefreshReason;
+
+        let rpki = self.db.rpki();
+
+        // Check if empty first
+        if rpki.is_empty() {
+            return Ok(Some(RefreshReason::Empty));
+        }
+
+        // Check if outdated
+        if rpki.needs_refresh(crate::database::DEFAULT_RPKI_CACHE_TTL) {
+            return Ok(Some(RefreshReason::Outdated));
+        }
+
+        Ok(None)
+    }
+
     /// Get cache metadata
     pub fn get_metadata(&self) -> Result<Option<crate::database::RpkiCacheMetadata>> {
         self.db.rpki().get_metadata()

--- a/src/lens/utils.rs
+++ b/src/lens/utils.rs
@@ -355,6 +355,38 @@ where
 }
 
 // =============================================================================
+// Data Refresh Status
+// =============================================================================
+
+/// Reason why data needs to be refreshed
+///
+/// This enum provides specific information about why a data refresh is needed,
+/// allowing for more informative user messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshReason {
+    /// Data tables don't exist or are empty
+    Empty,
+    /// Data exists but has expired based on TTL
+    Outdated,
+}
+
+impl RefreshReason {
+    /// Get a human-readable description of the refresh reason
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Empty => "data is empty",
+            Self::Outdated => "data is outdated",
+        }
+    }
+}
+
+impl std::fmt::Display for RefreshReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+// =============================================================================
 // Output Format and Display Utilities
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- CLI now shows specific reason for data refresh ("data is empty" vs "data is outdated") instead of generic "empty or outdated" message
- Added `RefreshReason` enum and `refresh_reason()` methods to lenses