### PR TITLE
refactor: conform config data and cache dirs to xdg spec

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -361,7 +361,7 @@ monocle = { version = "1.1", default-features = false, features = ["lib"] }
 use monocle::database::MonocleDatabase;
 use monocle::lens::inspect::{InspectLens, InspectQueryOptions};
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let lens = InspectLens::new(&db);
 let result = lens.query("AS13335", &InspectQueryOptions::default())?;
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+### Breaking Changes
+
+* Moved config, data, and cache paths to follow XDG base directory specification
+  * Config file default is now `$XDG_CONFIG_HOME/monocle/monocle.toml` (fallback: `~/.config/monocle/monocle.toml`)
+  * Data directory default is now `$XDG_DATA_HOME/monocle` (fallback: `~/.local/share/monocle`)
+  * Cache directory default is now `$XDG_CACHE_HOME/monocle` (fallback: `~/.cache/monocle`)
+  * Existing SQLite data under `~/.monocle` is no longer used by default and will be rebuilt in the new data location
+    * Legacy config migration: when the new config directory is empty, monocle copies `~/.monocle/monocle.toml` to the new config path
+    * Old database file will not be copied over. Once the updated monocle has been executed at least once, old `~/.monocle` can be safely deleted
+* Added `--use-cache` flag to `monocle search` to use the default XDG cache path (`$XDG_CACHE_HOME/monocle`)
+  * Value set by `--cache-dir` overrides `--use-cache` when both are provided
+
+### Dependencies
+
+* Switched directory resolution library from `dirs` to `etcetera`
+
 ## v1.1.0 - 2025-02-10
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,27 +645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +727,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -1666,8 +1655,8 @@ dependencies = [
  "clap",
  "config",
  "dateparser",
- "dirs",
  "dotenvy",
+ "etcetera",
  "futures",
  "futures-util",
  "humantime",
@@ -1776,12 +1765,6 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -2173,17 +2156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
 dependencies = [
  "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ full = ["cli"]
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 config = { version = "0.15", features = ["toml"] }
-dirs = "6"
+etcetera = "0.11.0"
 dotenvy = "0.15"
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,7 @@ cargo run --example inspect_lens --features lib
 use monocle::database::MonocleDatabase;
 use monocle::lens::rpki::{RpkiLens, RpkiValidationArgs};
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let lens = RpkiLens::new(&db);
 let result = lens.validate("1.1.1.0/24", 13335)?;
 ```

--- a/src/bin/commands/config.rs
+++ b/src/bin/commands/config.rs
@@ -81,6 +81,7 @@ pub enum ConfigCommands {
 struct ConfigInfo {
     config_file: String,
     data_dir: String,
+    cache_dir: String,
     cache_ttl: CacheTtlConfig,
     database: SqliteDatabaseInfo,
     server_defaults: ServerDefaults,
@@ -173,6 +174,7 @@ fn run_status(config: &MonocleConfig, verbose: bool, output_format: OutputFormat
     let config_info = ConfigInfo {
         config_file,
         data_dir: config.data_dir.clone(),
+        cache_dir: config.cache_dir(),
         cache_ttl: CacheTtlConfig {
             asinfo_secs: config.asinfo_cache_ttl_secs,
             as2rel_secs: config.as2rel_cache_ttl_secs,
@@ -241,6 +243,7 @@ fn print_config_table(info: &ConfigInfo, verbose: bool) {
     println!("General:");
     println!("  Config file:    {}", info.config_file);
     println!("  Data dir:       {}", info.data_dir);
+    println!("  Cache dir:      {}", info.cache_dir);
     println!();
 
     println!("Cache TTL:");
@@ -399,7 +402,10 @@ fn print_config_table(info: &ConfigInfo, verbose: bool) {
     eprintln!("Tips:");
     eprintln!("  Use --verbose (-v) to see all files in the data directory");
     eprintln!("  Use --format json for machine-readable output");
-    eprintln!("  Edit ~/.monocle/monocle.toml to customize settings");
+    eprintln!(
+        "  Edit {} to customize settings",
+        MonocleConfig::config_file_path()
+    );
     eprintln!("  Use 'monocle config sources' to see data source status");
     eprintln!("  Use 'monocle config update' to update data sources");
 }

--- a/src/bin/monocle.rs
+++ b/src/bin/monocle.rs
@@ -25,7 +25,7 @@ use commands::time::TimeArgs;
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
 struct Cli {
-    /// configuration file path, by default $HOME/.monocle.toml is used
+    /// configuration file path (default: $XDG_CONFIG_HOME/monocle/monocle.toml)
     #[clap(short, long)]
     config: Option<String>,
 
@@ -103,7 +103,7 @@ struct ServerArgs {
     #[clap(long, default_value_t = 8080)]
     port: u16,
 
-    /// Monocle data directory (default: $HOME/.monocle)
+    /// Monocle data directory (default: $XDG_DATA_HOME/monocle)
     #[clap(long)]
     data_dir: Option<String>,
 
@@ -175,7 +175,7 @@ fn main() {
     // matches just as you would the top level cmd
     match cli.command {
         Commands::Parse(args) => commands::parse::run(args, streaming_output_format),
-        Commands::Search(args) => commands::search::run(args, streaming_output_format),
+        Commands::Search(args) => commands::search::run(&config, args, streaming_output_format),
 
         Commands::Server(args) => {
             // The server requires the `server` feature (axum + tokio). Keep the CLI

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -85,7 +85,7 @@ manager.initialize()?;
 use monocle::database::MonocleDatabase;
 
 // Open the monocle database
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 
 // Bootstrap ASInfo data if needed
 if db.needs_asinfo_refresh(Duration::from_secs(7 * 24 * 60 * 60)) {
@@ -118,7 +118,7 @@ RPKI current data (ROAs and ASPAs) is stored in the monocle SQLite database and 
 ```rust
 use monocle::database::{MonocleDatabase, RpkiRepository, DEFAULT_RPKI_CACHE_TTL};
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let rpki = db.rpki();
 
 // Check metadata / whether refresh is needed
@@ -141,7 +141,7 @@ println!("{} {} -> {} ({})", result.prefix, result.asn, result.state, result.rea
 ```rust
 use monocle::database::{MonocleDatabase, DEFAULT_PFX2AS_CACHE_TTL};
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let pfx2as = db.pfx2as();
 
 // Check if refresh is needed

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -50,7 +50,7 @@
 //! use monocle::database::MonocleDatabase;
 //!
 //! // Open the monocle database
-//! let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+//! let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 //!
 //! // Bootstrap ASInfo data if needed
 //! if db.needs_asinfo_refresh(Duration::from_secs(7 * 24 * 60 * 60)) {

--- a/src/lens/README.md
+++ b/src/lens/README.md
@@ -197,7 +197,7 @@ use monocle::database::MonocleDatabase;
 use monocle::lens::inspect::{InspectLens, InspectQueryOptions};
 use monocle::lens::utils::OutputFormat;
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let lens = InspectLens::new(&db);
 
 // Query AS information
@@ -223,7 +223,7 @@ use monocle::database::MonocleDatabase;
 use monocle::lens::as2rel::{As2relLens, As2relSearchArgs};
 use monocle::lens::utils::OutputFormat;
 
-let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 let lens = As2relLens::new(&db);
 
 // Update data if needed

--- a/src/lens/pfx2as/mod.rs
+++ b/src/lens/pfx2as/mod.rs
@@ -336,7 +336,7 @@ impl Pfx2asSearchArgs {
 /// use monocle::database::MonocleDatabase;
 /// use monocle::lens::pfx2as::{Pfx2asLens, Pfx2asSearchArgs};
 ///
-/// let db = MonocleDatabase::open("~/.monocle/monocle-data.sqlite3")?;
+/// let db = MonocleDatabase::open("~/.local/share/monocle/monocle-data.sqlite3")?;
 /// let lens = Pfx2asLens::new(&db);
 ///
 /// // Search by prefix with RPKI validation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! use monocle::database::MonocleDatabase;
 //!
 //! // Open or create database
-//! let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+//! let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 //!
 //! // Check if AS2Rel data needs update
 //! use std::time::Duration;
@@ -102,7 +102,7 @@
 //! use monocle::database::MonocleDatabase;
 //! use monocle::lens::rpki::RpkiLens;
 //!
-//! let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+//! let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 //! let lens = RpkiLens::new(&db);
 //!
 //! // Ensure cache is populated
@@ -142,7 +142,7 @@
 //! use monocle::database::MonocleDatabase;
 //! use monocle::lens::inspect::{InspectLens, InspectQueryOptions};
 //!
-//! let db = MonocleDatabase::open_in_dir("~/.monocle")?;
+//! let db = MonocleDatabase::open_in_dir("~/.local/share/monocle")?;
 //! let lens = InspectLens::new(&db);
 //!
 //! // Auto-refresh data if needed

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -978,7 +978,7 @@ Get the status of all data sources.
   "type": "result",
   "data": {
     "sqlite": {
-      "path": "/home/user/.monocle/monocle.db",
+      "path": "/home/user/.local/share/monocle/monocle-data.sqlite3",
       "exists": true,
       "size_bytes": 52428800,
       "asinfo_count": 120415,
@@ -993,7 +993,7 @@ Get the status of all data sources.
       }
     },
     "cache": {
-      "directory": "/home/user/.monocle/cache",
+      "directory": "/home/user/.cache/monocle",
       "pfx2as_cache_count": 3
     }
   }
@@ -1321,7 +1321,7 @@ ping_interval = 30
 ```bash
 MONOCLE_SERVER_ADDRESS=0.0.0.0
 MONOCLE_SERVER_PORT=8800
-MONOCLE_DATA_DIR=~/.monocle
+MONOCLE_DATA_DIR=~/.local/share/monocle
 ```
 
 ---

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn test_ws_context_default() {
         let ctx = WsContext::default();
-        assert!(ctx.data_dir().contains(".monocle"));
+        assert!(ctx.data_dir().contains("monocle"));
     }
 
     #[test]


### PR DESCRIPTION
closes https://github.com/bgpkit/monocle/issues/111

aside from config and data dirs, i also found out there were hard coded paths for cache (dont seem to be used a lot), so i moved that one to `$XDG_CACHE_HOME/monocle` and fall back to `~/.cache/monocle`

otherwise please see changes indicated in change log