### PR TITLE
Add community filters to parse/search with strict positional matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ All notable changes to this project will be documented in this file.
 
 * Switched directory resolution library from `dirs` to `etcetera`
 
+### New Features
+
+* Added BGP community filtering support to `monocle parse` and `monocle search`
+  * New CLI option: `-C, --community` (with `--communities` alias)
+  * Supports repeated flags and comma-separated values
+  * Supports standard communities (`A:B`) and large communities (`A:B:C`)
+  * Supports wildcard matching per position with `*` (for example `*:100`, `1299:*`, `57866:*:*`)
+  * Uses strict positional matching with exact colon-count semantics
+    * `A:B` patterns match only standard communities
+    * `A:B:C` patterns match only large communities
+    * Example: `1299:*` does not match `1403:1299`
+
 ## v1.1.0 - 2025-02-10
 
 ### Breaking Changes

--- a/examples/parse_lens.rs
+++ b/examples/parse_lens.rs
@@ -16,11 +16,13 @@ fn main() -> anyhow::Result<()> {
     // Parse with filters
     let filters = ParseFilters {
         origin_asn: vec!["13335".to_string()],
+        communities: vec!["*:100".to_string()],
         ..Default::default()
     };
 
     println!("Parsing MRT file with filters:");
     println!("  Origin ASN: 13335 (Cloudflare)");
+    println!("  Community: *:100");
 
     let url = "https://data.ris.ripe.net/rrc00/2024.01/updates.20240101.0000.gz";
     let elems = lens.parse_with_progress(&filters, url, None)?;

--- a/examples/search_lens.rs
+++ b/examples/search_lens.rs
@@ -17,6 +17,7 @@ fn main() -> anyhow::Result<()> {
         parse_filters: ParseFilters {
             start_ts: Some("2025-01-01T00:00:00Z".to_string()),
             end_ts: Some("2025-01-01T01:00:00Z".to_string()),
+            communities: vec!["*:100".to_string()],
             ..Default::default()
         },
         collector: Some("rrc00".to_string()),
@@ -25,6 +26,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     println!("Searching for BGP messages...");
+    println!("Filter: community *:100");
 
     let broker = filters.build_broker()?;
     let items = broker.query()?;

--- a/src/lens/search/mod.rs
+++ b/src/lens/search/mod.rs
@@ -617,6 +617,7 @@ mod tests {
                 include_sub: false,
                 peer_ip: Vec::new(),
                 peer_asn: Vec::new(),
+                communities: Vec::new(),
                 elem_type: None,
                 start_ts: Some("2022-01-01T00:00:00Z".to_string()),
                 end_ts: Some("2022-01-01T01:00:00Z".to_string()), // 1 hour window
@@ -705,6 +706,7 @@ mod tests {
                 include_sub: false,
                 peer_ip: Vec::new(),
                 peer_asn: Vec::new(),
+                communities: Vec::new(),
                 elem_type: None,
                 start_ts: Some("2022-01-01T00:00:00Z".to_string()),
                 end_ts: Some("2022-01-01T01:00:00Z".to_string()),
@@ -757,5 +759,22 @@ mod tests {
         };
         let json = serde_json::to_string(&progress).expect("Failed to serialize");
         assert!(json.contains("percent_complete"));
+    }
+
+    #[test]
+    fn test_search_filters_validate_with_communities() {
+        let filters = SearchFilters {
+            parse_filters: ParseFilters {
+                communities: vec!["*:100".to_string(), "15169:*".to_string()],
+                start_ts: Some("2025-01-01T00:00:00Z".to_string()),
+                end_ts: Some("2025-01-01T01:00:00Z".to_string()),
+                ..Default::default()
+            },
+            collector: Some("rrc00".to_string()),
+            project: Some("riperis".to_string()),
+            dump_type: SearchDumpType::Updates,
+        };
+
+        assert!(filters.validate().is_ok());
     }
 }


### PR DESCRIPTION
Summary
- add community filter support to monocle parse and monocle search
- support standard (A:B) and large (A:B:C) community patterns
- support wildcard by position (*) with strict colon-count and positional matching
- translate community patterns to anchored parser regex for exact part matching
- update parse/search examples to include wildcard community usage
- update changelog (Unreleased) with the new feature behavior

Notes
- parser filter key uses community (singular)
- strict behavior example: 1299:* does not match 1403:1299

Testing
- cargo fmt
- added/updated unit tests for community validation and pattern conversion logic