### PR TITLE
Fix RPKI Archive Repo Name Typo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bcder"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7c42c9913f68cf9390a225e81ad56a5c515347287eb98baa710090ca1de86d"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "bgpkit-broker"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,10 +274,11 @@ dependencies = [
 
 [[package]]
 name = "bgpkit-commons"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c583f55fdbfe590bd3a6b8ad17e60631c8e82c5a25363760aa372cc9ca8dc92d"
+checksum = "b9d8f5677cf6947ba71e62243875f9ce0df3e538149754a36309fdec9d970ffb"
 dependencies = [
+ "bcder",
  "chrono",
  "ipnet",
  "ipnet-trie",
@@ -278,6 +289,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -4097,3 +4109,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ dateparser = { version = "0.2", optional = true }
 humantime = { version = "2.1", optional = true }
 bgpkit-broker = { version = "0.10.1", optional = true }
 bgpkit-parser = { version = "0.15.0", features = ["serde"], optional = true }
-bgpkit-commons = { version = "0.10.2", features = ["asinfo", "rpki", "countries"], optional = true }
+bgpkit-commons = { version = "0.10.3", features = ["asinfo", "rpki", "countries"], optional = true }
 itertools = { version = "0.14", optional = true }
 radar-rs = { version = "0.1.0", optional = true }
 rayon = { version = "1.8", optional = true }

--- a/README.md
+++ b/README.md
@@ -1243,7 +1243,7 @@ Options:
       --date <DATE>            Load historical data for this date (YYYY-MM-DD)
       --debug                  Print debug information
       --source <SOURCE>        Historical data source: ripe, rpkiviews (default: ripe) [default: ripe]
-      --collector <COLLECTOR>  RPKIviews collector: soborost, massars, attn, kerfuffle (default: soborost) [default: soborost]
+      --collector <COLLECTOR>  RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost) [default: sobornost]
       --format <FORMAT>        Output format: table, markdown, json, json-pretty, json-line, psv (default varies by command)
       --json                   Output as JSON objects (shortcut for --format json-pretty)
   -r, --refresh                Force refresh the RPKI cache (only applies to current data)
@@ -1295,7 +1295,7 @@ Options:
       --format <FORMAT>        Output format: table, markdown, json, json-pretty, json-line, psv (default varies by command)
       --json                   Output as JSON objects (shortcut for --format json-pretty)
       --source <SOURCE>        Historical data source: ripe, rpkiviews (default: ripe) [default: ripe]
-      --collector <COLLECTOR>  RPKIviews collector: soborost, massars, attn, kerfuffle (default: soborost) [default: soborost]
+      --collector <COLLECTOR>  RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost) [default: sobornost]
       --no-update              Disable automatic database updates (use existing cached data only)
   -r, --refresh                Force refresh the RPKI cache (only applies to current data)
   -h, --help                   Print help

--- a/src/bin/commands/rpki.rs
+++ b/src/bin/commands/rpki.rs
@@ -40,8 +40,8 @@ pub enum RpkiCommands {
         #[clap(long, default_value = "ripe")]
         source: String,
 
-        /// RPKIviews collector: soborost, massars, attn, kerfuffle (default: soborost)
-        #[clap(long, default_value = "soborost")]
+        /// RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost)
+        #[clap(long, default_value = "sobornost")]
         collector: String,
 
         /// Force refresh the RPKI cache (only applies to current data)
@@ -67,8 +67,8 @@ pub enum RpkiCommands {
         #[clap(long, default_value = "ripe")]
         source: String,
 
-        /// RPKIviews collector: soborost, massars, attn, kerfuffle (default: soborost)
-        #[clap(long, default_value = "soborost")]
+        /// RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost)
+        #[clap(long, default_value = "sobornost")]
         collector: String,
 
         /// Force refresh the RPKI cache (only applies to current data)
@@ -425,7 +425,7 @@ fn parse_data_source(source: &str) -> RpkiDataSource {
 
 fn parse_collector(collector: &str) -> Option<RpkiViewsCollectorOption> {
     match collector.to_lowercase().as_str() {
-        "soborost" => Some(RpkiViewsCollectorOption::Soborost),
+        "sobornost" => Some(RpkiViewsCollectorOption::Sobornost),
         "massars" => Some(RpkiViewsCollectorOption::Massars),
         "attn" => Some(RpkiViewsCollectorOption::Attn),
         "kerfuffle" => Some(RpkiViewsCollectorOption::Kerfuffle),

--- a/src/lens/rpki/commons.rs
+++ b/src/lens/rpki/commons.rs
@@ -122,6 +122,8 @@ pub fn load_historical_rpki(date: NaiveDate, source: HistoricalRpkiSource) -> Re
             .map_err(|e| anyhow!("Failed to load RIPE historical RPKI data: {}", e)),
         HistoricalRpkiSource::RpkiViews(collector) => RpkiTrie::from_rpkiviews(collector, date)
             .map_err(|e| anyhow!("Failed to load RPKIviews RPKI data: {}", e)),
+        HistoricalRpkiSource::RpkiSpools(collector) => RpkiTrie::from_rpkispools(collector, date)
+            .map_err(|e| anyhow!("Failed to load RPKISpools RPKI data: {}", e)),
     }
 }
 

--- a/src/lens/rpki/commons.rs
+++ b/src/lens/rpki/commons.rs
@@ -80,12 +80,12 @@ impl From<&RpkiAspaEntry> for RpkiAspaTableEntry {
 /// Parse RPKIviews collector from string
 pub fn parse_rpkiviews_collector(collector: &str) -> Result<RpkiViewsCollector> {
     match collector.to_lowercase().as_str() {
-        "soborost" | "soborostnet" => Ok(RpkiViewsCollector::SoborostNet),
+        "sobornost" | "sobornostnet" => Ok(RpkiViewsCollector::SobornostNet),
         "massars" | "massarsnet" => Ok(RpkiViewsCollector::MassarsNet),
         "attn" | "attnjp" => Ok(RpkiViewsCollector::AttnJp),
         "kerfuffle" | "kerfufflenet" => Ok(RpkiViewsCollector::KerfuffleNet),
         _ => Err(anyhow!(
-            "Unknown RPKIviews collector: {}. Valid options: soborost, massars, attn, kerfuffle",
+            "Unknown RPKIviews collector: {}. Valid options: sobornost, massars, attn, kerfuffle",
             collector
         )),
     }
@@ -99,7 +99,7 @@ pub fn parse_historical_source(
     match source.to_lowercase().as_str() {
         "ripe" => Ok(HistoricalRpkiSource::Ripe),
         "rpkiviews" => {
-            let collector = collector.unwrap_or("soborost");
+            let collector = collector.unwrap_or("sobornost");
             let rpkiviews_collector = parse_rpkiviews_collector(collector)?;
             Ok(HistoricalRpkiSource::RpkiViews(rpkiviews_collector))
         }
@@ -260,8 +260,8 @@ mod tests {
     #[test]
     fn test_parse_rpkiviews_collector() {
         assert!(matches!(
-            parse_rpkiviews_collector("soborost").unwrap(),
-            RpkiViewsCollector::SoborostNet
+            parse_rpkiviews_collector("sobornost").unwrap(),
+            RpkiViewsCollector::SobornostNet
         ));
         assert!(matches!(
             parse_rpkiviews_collector("kerfuffle").unwrap(),
@@ -277,8 +277,8 @@ mod tests {
             HistoricalRpkiSource::Ripe
         ));
         assert!(matches!(
-            parse_historical_source("rpkiviews", Some("soborost")).unwrap(),
-            HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::SoborostNet)
+            parse_historical_source("rpkiviews", Some("sobornost")).unwrap(),
+            HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::SobornostNet)
         ));
     }
 }

--- a/src/lens/rpki/mod.rs
+++ b/src/lens/rpki/mod.rs
@@ -60,9 +60,9 @@ pub enum RpkiDataSource {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum RpkiViewsCollectorOption {
-    /// SoborostNet collector (default)
+    /// SobornostNet collector (default)
     #[default]
-    Soborost,
+    Sobornost,
     /// MassarsNet collector
     Massars,
     /// AttnJp collector
@@ -814,7 +814,7 @@ impl<'a> RpkiLens<'a> {
         };
 
         let collector_str = collector.map(|c| match c {
-            RpkiViewsCollectorOption::Soborost => "soborost",
+            RpkiViewsCollectorOption::Sobornost => "sobornost",
             RpkiViewsCollectorOption::Massars => "massars",
             RpkiViewsCollectorOption::Attn => "attn",
             RpkiViewsCollectorOption::Kerfuffle => "kerfuffle",


### PR DESCRIPTION
[RPKIViews'](https://rpkiviews.org/) default source is Job's server under the sobor**n**ost domain name: `josephine.sobornost.net`.

Unfortunately, throughout bgpkit `soborost` is used.

This PR fixes all instances and corrects the typo across the git repo. However, this means that whoever was using this with the previous typo will face a breaking change.

Since this was the default value I think there aren't probably any users that had this hardcoded explicitly, but do you think it would make sense to have a second value map to the correct internal `RpkiViewsCollectorOption` ? I can modify this PR to do it, it should be a couple of minutes.