### PR TITLE
fix: restore RIB search results and command parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+* Fixed `search --dump-type rib` applying the requested snapshot time window to
+  per-route timestamps inside matching RIB dumps. Stable routes learned before
+  the dump timestamp are now retained, restoring AS-path search results (#136,
+  #138).
 * Fixed `rib` command dropping RIB entries whose per-route timestamp predates
   the RIB dump time. The base RIB parser was incorrectly applying a `start_ts`
   filter at the dump timestamp, silently excluding stable routes learned days
@@ -15,6 +19,11 @@ All notable changes to this project will be documented in this file.
   is exclusive, so a RIB starting exactly at the target was excluded, forcing
   the code to select the previous RIB and replay unnecessary update files.
   This caused ~3× slowdown for common midnight RIB queries.
+
+### New Features
+
+* Added `--use-cache` / `--cache-dir` MRT-file caching and `--fields` output
+  selection to the `rib` command (#137).
 
 ### Performance Improvements
 

--- a/src/bin/commands/rib.rs
+++ b/src/bin/commands/rib.rs
@@ -56,6 +56,7 @@ fn run_stdout(
     output_format: OutputFormat,
     no_update: bool,
 ) -> Result<()> {
+    let fields = parse_fields(&args.fields)?;
     let stdout = std::io::stdout();
     let mut stdout = BufWriter::new(stdout.lock());
 
@@ -73,12 +74,8 @@ fn run_stdout(
         )?;
 
         if !entries.is_empty() {
-            writeln!(
-                stdout,
-                "{}",
-                format_entries_table(&entries, DEFAULT_FIELDS_RIB)
-            )
-            .map_err(|e| anyhow!("Failed to write table output: {}", e))?;
+            writeln!(stdout, "{}", format_entries_table(&entries, &fields))
+                .map_err(|e| anyhow!("Failed to write table output: {}", e))?;
         }
         return Ok(());
     }
@@ -89,7 +86,7 @@ fn run_stdout(
         no_update,
         |_rib_ts, state_store, _filtered_updates| {
             if !header_written {
-                if let Some(header) = get_header(output_format, DEFAULT_FIELDS_RIB) {
+                if let Some(header) = get_header(output_format, &fields) {
                     writeln!(stdout, "{}", header)
                         .map_err(|e| anyhow!("Failed to write output header: {}", e))?;
                 }
@@ -97,7 +94,7 @@ fn run_stdout(
             }
 
             state_store.visit_entries(|entry| {
-                if let Some(line) = format_entry(entry, output_format, DEFAULT_FIELDS_RIB) {
+                if let Some(line) = format_entry(entry, output_format, &fields) {
                     writeln!(stdout, "{}", line)
                         .map_err(|e| anyhow!("Failed to write reconstructed RIB row: {}", e))?;
                 }
@@ -131,6 +128,36 @@ fn run_sqlite_output(lens: &RibLens<'_>, args: &RibArgs, no_update: bool) -> Res
         output_path.display()
     );
     Ok(())
+}
+
+fn parse_fields(fields_arg: &Option<String>) -> Result<Vec<&'static str>> {
+    match fields_arg {
+        None => Ok(DEFAULT_FIELDS_RIB.to_vec()),
+        Some(fields_arg) => {
+            let fields = fields_arg
+                .split(',')
+                .map(str::trim)
+                .filter(|field| !field.is_empty())
+                .map(|field| {
+                    DEFAULT_FIELDS_RIB
+                        .iter()
+                        .copied()
+                        .find(|available| *available == field)
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "Unknown RIB output field '{}'. Available fields: {}",
+                                field,
+                                DEFAULT_FIELDS_RIB.join(", ")
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            if fields.is_empty() {
+                return Err(anyhow!("--fields must name at least one output field"));
+            }
+            Ok(fields)
+        }
+    }
 }
 
 fn format_entries_table(entries: &[StoredRibEntry], fields: &[&str]) -> String {

--- a/src/lens/rib/mod.rs
+++ b/src/lens/rib/mod.rs
@@ -6,7 +6,7 @@
 //! 3. Materializing only the final route state for each requested `rib_ts`
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -100,6 +100,20 @@ pub struct RibArgs {
     /// SQLite output file path.
     #[cfg_attr(feature = "cli", clap(long))]
     pub sqlite_path: Option<PathBuf>,
+
+    /// Use the default XDG cache directory ($XDG_CACHE_HOME/monocle) for MRT files.
+    /// Overridden by --cache-dir if both are specified.
+    #[cfg_attr(feature = "cli", clap(long))]
+    #[serde(default)]
+    pub use_cache: bool,
+
+    /// Override cache directory for downloaded MRT files.
+    #[cfg_attr(feature = "cli", clap(long))]
+    pub cache_dir: Option<PathBuf>,
+
+    /// Comma-separated list of fields to output.
+    #[cfg_attr(feature = "cli", clap(long, short = 'f', value_name = "FIELDS"))]
+    pub fields: Option<String>,
 }
 
 impl RibArgs {
@@ -231,6 +245,7 @@ impl<'a> RibLens<'a> {
 
             self.load_base_rib(
                 &mut state_store,
+                args,
                 &group.collector,
                 &group.rib_item,
                 &safe_base_filters,
@@ -630,6 +645,7 @@ impl<'a> RibLens<'a> {
     fn load_base_rib(
         &self,
         state_store: &mut RibStateStore,
+        args: &RibArgs,
         collector: &str,
         rib_item: &BrokerItem,
         safe_filters: &ParseFilters,
@@ -638,7 +654,8 @@ impl<'a> RibLens<'a> {
         as_path_regex: Option<&Regex>,
         full_feed_allowlist: Option<&HashSet<(String, u32)>>,
     ) -> Result<()> {
-        let parser = safe_filters.to_parser(&rib_item.url).map_err(|e| {
+        let input_path = self.input_path(args, collector, &rib_item.url)?;
+        let parser = safe_filters.to_parser(&input_path).map_err(|e| {
             anyhow!(
                 "Failed to build parser for base RIB {}: {}",
                 rib_item.url,
@@ -709,7 +726,8 @@ impl<'a> RibLens<'a> {
                     .last()
                     .ok_or_else(|| anyhow!("Replay group missing max rib_ts"))?,
             );
-            let parser = safe_filters.to_parser(&update.url).map_err(|e| {
+            let input_path = self.input_path(args, &group.collector, &update.url)?;
+            let parser = safe_filters.to_parser(&input_path).map_err(|e| {
                 anyhow!(
                     "Failed to build parser for updates file {}: {}",
                     update.url,
@@ -971,6 +989,45 @@ impl<'a> RibLens<'a> {
         }
     }
 
+    fn input_path(&self, args: &RibArgs, collector: &str, url: &str) -> Result<String> {
+        let cache_dir = args.cache_dir.as_ref().cloned().or_else(|| {
+            args.use_cache
+                .then(|| PathBuf::from(self.config.cache_dir()))
+        });
+        let Some(cache_dir) = cache_dir else {
+            return Ok(url.to_string());
+        };
+
+        let cache_path = Self::cache_path(&cache_dir, collector, url)
+            .ok_or_else(|| anyhow!("Cannot construct cache path for {}", url))?;
+        if !cache_path.exists() {
+            if let Some(parent) = cache_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let partial_path = cache_path.with_file_name(format!(
+                "{}.partial",
+                cache_path.file_name().unwrap_or_default().to_string_lossy()
+            ));
+            oneio::download(url, partial_path.to_str().unwrap_or_default(), None)?;
+            std::fs::rename(partial_path, &cache_path)?;
+        }
+        Ok(cache_path.to_string_lossy().into_owned())
+    }
+
+    fn cache_path(cache_dir: &Path, collector: &str, url: &str) -> Option<PathBuf> {
+        let path = url
+            .strip_prefix("https://")
+            .or_else(|| url.strip_prefix("http://"))
+            .and_then(|rest| rest.find('/').map(|index| &rest[index..]))?
+            .trim_start_matches('/');
+        let relative_path = if path.starts_with(collector) {
+            path.to_string()
+        } else {
+            format!("{}/{}", collector, path)
+        };
+        Some(cache_dir.join(relative_path))
+    }
+
     fn base_broker(&self, args: &RibArgs) -> BgpkitBroker {
         let mut broker = BgpkitBroker::new().page_size(1000);
         if let Some(collector) = &args.filters.collector {
@@ -1101,6 +1158,9 @@ mod tests {
                 ..Default::default()
             },
             sqlite_path: None,
+            use_cache: false,
+            cache_dir: None,
+            fields: None,
         }
     }
 
@@ -1142,6 +1202,20 @@ mod tests {
             .starts_with("country-ir-origin-13335+15169-peer-2914-collector-route_views2+rrc00"));
         assert!(slug.contains("-h"));
         Ok(())
+    }
+
+    #[test]
+    fn test_cache_path_matches_search_cache_layout() {
+        assert_eq!(
+            RibLens::cache_path(
+                Path::new("/tmp/cache"),
+                "rrc00",
+                "https://data.ris.ripe.net/rrc00/2026.06/bview.20260601.0000.gz"
+            ),
+            Some(PathBuf::from(
+                "/tmp/cache/rrc00/2026.06/bview.20260601.0000.gz"
+            ))
+        );
     }
 
     #[test]

--- a/src/lens/search/mod.rs
+++ b/src/lens/search/mod.rs
@@ -307,9 +307,23 @@ impl SearchFilters {
         Ok(())
     }
 
-    /// Convert filters to a BgpkitParser for a given file
+    /// Convert filters to a BgpkitParser for a given file.
+    ///
+    /// RIB dumps are snapshots: their per-route timestamps describe when a route
+    /// was learned, not the timestamp of the dump. Applying a search time window
+    /// to those timestamps would drop stable routes from a matching RIB file.
     pub fn to_parser(&self, file_path: &str) -> Result<BgpkitParser<Box<dyn Read + Send>>> {
-        self.parse_filters.to_parser(file_path)
+        self.parser_filters().to_parser(file_path)
+    }
+
+    fn parser_filters(&self) -> ParseFilters {
+        let mut parse_filters = self.parse_filters.clone();
+        if self.dump_type == SearchDumpType::Rib {
+            parse_filters.start_ts = None;
+            parse_filters.end_ts = None;
+            parse_filters.duration = None;
+        }
+        parse_filters
     }
 }
 
@@ -931,6 +945,23 @@ impl Default for SearchLens {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_rib_parser_filters_do_not_apply_snapshot_time_window() {
+        let filters = SearchFilters {
+            parse_filters: ParseFilters {
+                start_ts: Some("2026-06-01T00:00:00Z".to_string()),
+                end_ts: Some("2026-06-01T00:00:00Z".to_string()),
+                ..Default::default()
+            },
+            dump_type: SearchDumpType::Rib,
+            ..Default::default()
+        };
+
+        let parser_filters = filters.parser_filters();
+        assert_eq!(parser_filters.start_ts, None);
+        assert_eq!(parser_filters.end_ts, None);
+    }
 
     #[test]
     fn test_pagination_logic() {


### PR DESCRIPTION
## Summary

* Preserve matching RIB snapshot entries regardless of each routes learned timestamp, restoring RIB AS-path searches.
* Add `rib --use-cache` / `--cache-dir` and `rib --fields` support.
* Add regression coverage for RIB time semantics and cache paths.

Fixes #136
Fixes #137
Fixes #138

## Validation

* `cargo fmt -- --check`
* `cargo test --all-features`
* `cargo clippy --lib --all-features -- -D warnings`
