### PR TITLE
feat: add SSE search result statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+* Added final SSE search statistics: matched elements, source-file counts and
+  compressed-byte metadata, rate, and matching collectors/files. `completed`,
+  `cancelled`, and `error` now carry the same `SearchStreamResult` payload.
 * Added `--use-cache` / `--cache-dir` MRT-file caching and `--fields` output
   selection to the `rib` command (#137).
 

--- a/SSE_SEARCH_STATISTICS_DESIGN.md
+++ b/SSE_SEARCH_STATISTICS_DESIGN.md
@@ -1,0 +1,226 @@
+# SSE Search Terminal Statistics Design (#135)
+
+## 1. Overview
+
+Extend `POST /api/v1/search/stream` so every terminal SSE event reports an unambiguous summary of the search work and its results. The server already emits a `completed` event containing `SearchSummary`, but it does not identify matching sources, source-byte totals, throughput, or whether a counter means matched elements versus all BGP messages parsed.
+
+The design preserves the bounded-channel, cancellation, max-result, timeout, and one-terminal-event guarantees of the current shared search executor.
+
+## 2. Motivation and Use Cases
+
+- A UI can show a final, trustworthy “N matching elements from M files” result without reconstructing it from intermittent progress events.
+- Operators can compare searches by source data volume and matched-element rate.
+- Clients can retain the collectors and files that actually produced matches for audit, download, or follow-up analysis.
+- A client can distinguish a successful empty search from an incomplete/cancelled search.
+
+| Aspect | Current terminal event | Proposed terminal event |
+|---|---|---|
+| Result count | `total_messages` (actually matched elements) | Explicit `matched_elements` |
+| File outcome | totals only | totals plus matching source list |
+| Source volume | unavailable | broker-advertised compressed bytes |
+| Rate | unavailable | matched elements/sec |
+| Stop state | separate event name | event name plus `exit_reason` and partial metrics |
+
+## 3. Design Decisions
+
+**Use a server-only `SearchStreamStats` payload instead of changing the public `SearchSummary` struct.** `SearchSummary` is a library API used by CLI and lens consumers. The additional source metadata is meaningful only to SSE and should not force unrelated callers to carry server accounting state.
+
+**Call the existing `total_messages` counter `matched_elements` at the API boundary.** The shared executor increments it only when it reserves output slots for filtered `BgpElem`s. Calling it “messages processed” would be false whenever filters exclude data or a BGP message yields multiple elements.
+
+**Report broker-advertised compressed source bytes, with availability metadata.** Sum `BrokerItem.exact_size` when positive and otherwise `rough_size`; call this `source_bytes_compressed`. It is the amount of source material selected, not a count of bytes actually downloaded before cancellation. Do not report uncompressed bytes in this release: the current parser/reader API exposes no reliable decompressed-byte counter.
+
+**Do not claim a raw BGP-message count in the first implementation.** `BgpkitParser` exposes filtered element iteration but no parser-work counter. Counting every record would require either upstream parser instrumentation or reimplementing filtering in Monocle. The terminal payload therefore has no `messages_processed` field; a future additive field may expose it once parser support exists.
+
+**Report matched files and collectors only.** A source is included after its first accepted element batch. This gives clients useful follow-up sources without emitting a potentially enormous list of all queried files. Ordering is deterministic: sort collectors and source records at terminal serialization.
+
+**Attach statistics to all final stream-result payloads.** `completed`, `cancelled`, and `error` retain their distinct SSE event names and remain mutually exclusive. They each carry a `SearchStreamResult` object. This replaces the current `null` cancelled payload and bare API-error payload; document it as a v1 additive/shape adjustment before implementation. The terminal payload makes partial work observable for cancellation, timeout, and execution errors.
+
+**Keep collection in the SSE sink and immutable source plan in the executor outcome.** The sink already receives accepted batches and is shared by Rayon workers, so a mutex-protected set is the correct point to record matches. The executor owns broker items and can calculate selected source bytes before parallel processing.
+
+## 4. Data Structures
+
+Add these server-facing types in `src/server/search.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchStreamResult {
+    pub exit_reason: SearchExitReason,
+    pub stats: SearchStreamStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ApiErrorResponse>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchStreamStats {
+    /// Filtered BGP elements accepted for SSE output; not raw BGP messages.
+    pub matched_elements: u64,
+    pub total_files: usize,
+    pub successful_files: usize,
+    pub failed_files: usize,
+    /// Broker-advertised compressed bytes for all selected source files.
+    pub source_bytes_compressed: u64,
+    /// Always false in this version; retained as explicit semantic metadata.
+    pub source_bytes_exact: bool,
+    pub duration_secs: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_elements_per_sec: Option<f64>,
+    pub matching_collectors: Vec<String>,
+    pub matching_files: Vec<MatchingFile>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MatchingFile {
+    pub collector: String,
+    pub file_url: String,
+}
+```
+
+Extend the lens outcome internally, without altering `SearchSummary`:
+
+```rust
+pub struct SearchOutcome {
+    pub summary: SearchSummary,
+    pub exit_reason: SearchExitReason,
+    pub source_bytes_compressed: u64,
+    pub source_bytes_exact: bool,
+}
+```
+
+`source_bytes_exact` is true only when every selected `BrokerItem.exact_size > 0`; when false, `rough_size` was used for one or more files. The sum remains useful but must not be interpreted as measured transferred bytes.
+
+Replace the SSE sink state with:
+
+```rust
+struct SseSearchState {
+    matching_files: BTreeSet<MatchingFile>,
+}
+```
+
+A `BTreeSet` deduplicates batches from the same file and supplies deterministic output. `total_so_far` is removed from sink state; `SearchElementBatch`/the executor’s atomic matched-elements counter is the source of truth. Add `total_so_far` to the batch at emission time or continue deriving it via a dedicated atomic passed to the sink so element events remain monotonically counted under parallel processing.
+
+## 5. Algorithm
+
+1. `SearchLens::search_with_options` queries the broker as it does today.
+2. Before moving `items` into Rayon, calculate `source_bytes_compressed` and `source_bytes_exact` from the selected `BrokerItem`s.
+3. Process each item with the current parser/filter pipeline. Do **not** add a second unfiltered parser pass.
+4. When `emit_search_batch` reserves at least one result slot, it invokes `SseSearchSink::on_elements`.
+5. The SSE sink locks `SseSearchState`, inserts `{collector, file_url}` into `matching_files`, and sends the element event. If the channel is closed, it sets cancellation and returns `Stop`, exactly as today.
+6. On exit, `run_search_worker` takes a snapshot of the sink’s sorted matching set and combines it with `SearchOutcome` and elapsed duration to make `SearchStreamStats`.
+7. Emit exactly one terminal event:
+   - normal completion or `max_results` → `event: completed`, `exit_reason: "completed"` or `"max_results_reached"`;
+   - client disconnect/sink stop → `event: cancelled`, `exit_reason: "cancelled"`;
+   - timeout or executor failure → `event: error`, with an `error` object and `exit_reason: "timeout"` or `"error"`.
+8. Do not send progress or element events after the terminal send. Existing `send_event` blocking semantics remain unchanged.
+
+Worked example:
+
+- Broker selects three files totaling 120 MB (100 MB exact + 20 MB rough), from `rrc00` and `rrc01`.
+- Filters accept elements only from one `rrc00` file, producing two batches and 150 elements.
+- The terminal stats contain `matched_elements: 150`, `matching_collectors: ["rrc00"]`, one matching-file record, `source_bytes_compressed: 125829120`, `source_bytes_exact: false`, and `matched_elements_per_sec: 75.0` for a two-second run.
+
+## 6. Output Format
+
+Successful terminal event:
+
+```text
+event: completed
+data: {"exit_reason":"completed","stats":{"matched_elements":150,"total_files":3,"successful_files":3,"failed_files":0,"source_bytes_compressed":125829120,"source_bytes_exact":false,"duration_secs":2.0,"matched_elements_per_sec":75.0,"matching_collectors":["rrc00"],"matching_files":[{"collector":"rrc00","file_url":"https://data.ris.ripe.net/rrc00/2026.06/updates.20260601.0000.gz"}]}}
+```
+
+Cancelled terminal event (partial work is retained):
+
+```text
+event: cancelled
+data: {"exit_reason":"cancelled","stats":{"matched_elements":64,"total_files":10,"successful_files":1,"failed_files":1,"source_bytes_compressed":524288000,"source_bytes_exact":true,"duration_secs":1.4,"matched_elements_per_sec":45.7,"matching_collectors":["rrc00"],"matching_files":[...]}}
+```
+
+No file is written; this is the terminal frame of the existing SSE stream.
+
+## 7. Changes to Existing Files
+
+### `src/lens/search/mod.rs`
+
+- Extend `SearchOutcome` with source-byte fields shown above.
+- Immediately after `let items = self.query_broker(filters)?`, calculate:
+
+```rust
+let source_bytes_exact = items.iter().all(|item| item.exact_size > 0);
+let source_bytes_compressed = items.iter().map(|item| {
+    u64::try_from(if item.exact_size > 0 { item.exact_size } else { item.rough_size })
+        .unwrap_or(0)
+}).sum();
+```
+
+- Include those values in every `SearchOutcome` return, including timeout-before-work and zero-file paths.
+- Keep `SearchSummary.total_messages` unchanged for library compatibility; document in its Rustdoc that it is matched elements.
+
+### `src/server/search.rs`
+
+- Replace `Completed(SearchSummary)`, `Cancelled`, and `Error(ApiErrorResponse)` in `SearchStreamEvent` with final-result variants carrying `SearchStreamResult`.
+- Add `SearchStreamResult`, `SearchStreamStats`, and `MatchingFile`.
+- Make `SseSearchSink::snapshot_matching_files()` clone its sorted set after executor completion.
+- Build terminal stats in `run_search_worker`; derive `matched_elements_per_sec` from `outcome.summary.total_messages / duration_secs` when duration is positive.
+- Preserve `Started`, `Progress`, `Elements`, bounded channel capacity, and `send_event` behavior.
+- Update SSE serialization tests for all terminal event names and payloads.
+
+### `src/server/README.md`
+
+- Replace the final-event table payload descriptions with `SearchStreamResult`.
+- Define `matched_elements`, selected-source compressed bytes, `source_bytes_exact`, and matching-source semantics.
+- State that raw BGP-message and uncompressed-byte counters are not yet reported.
+- Update the terminal invariant wording to cover terminal objects for cancellation and errors.
+
+### `CHANGELOG.md`
+
+Add an Unreleased **New Features** item describing terminal SSE statistics and explicitly noting matching-element semantics.
+
+## 8. New Files
+
+No production files are required. The feature fits the existing server search module and shared lens executor.
+
+Optionally add `tests/sse_search_terminal.rs` if the project’s server test harness can construct deterministic local MRT input; otherwise keep unit tests adjacent to `src/server/search.rs` and executor tests in `src/lens/search/mod.rs`.
+
+## 9. Unit Tests
+
+- Selected items with all positive `exact_size` values → exact compressed-byte total and `source_bytes_exact: true`.
+- A selected item with no exact size → `rough_size` used and `source_bytes_exact: false`.
+- Zero matching batches → empty collectors/files and zero matched elements.
+- Two batches from the same file → one matching-file entry.
+- Batches from two collectors arrive in reverse order → terminal collectors/files are sorted.
+- Normal completion → one `completed` terminal frame with stats.
+- Max-results exit → one `completed` frame with `max_results_reached` reason and capped matched elements.
+- Sink/channel closure → one `cancelled` terminal frame with partial stats and no later event.
+- Timeout → one `error` terminal frame with partial stats and timeout error.
+- Executor error before any file parses → one `error` terminal frame with zero match sources.
+- Existing progress and element events remain unchanged and no terminal event is duplicated.
+- **CLI end-to-end:** start `monocle server` on an ephemeral local port, run `monocle search --remote-url http://127.0.0.1:<port>/api/v1/search/stream` against it, and assert the client consumes `started`, `elements`, and the final result event without protocol or deserialization errors. Use a deterministic local MRT fixture or mockable broker/parser source; do not make this CI test depend on a live archive.
+
+## 10. Open Questions
+
+**Question:** Should `max_results_reached` have its own terminal SSE event name?
+
+**Default:** No. Keep `completed` as the event name and expose `exit_reason`; clients already treat it as a successful, intentionally bounded result.
+
+**Question:** Should terminal stats include every selected file, not only files with matches?
+
+**Default:** No. `total_files` and byte totals describe selection; `matching_files` is intentionally a concise follow-up list.
+
+**Question:** When can `messages_processed` be added?
+
+**Default:** Only after `bgpkit-parser` exposes a reliable counter for records/messages read before filtering. Do not infer it from matched elements.
+
+## 11. Implementation Sequence
+
+1. Extend `SearchOutcome` and calculate source-byte metadata in `src/lens/search/mod.rs`; add deterministic unit tests.
+2. Add final stream-result DTOs and matching-source state to `src/server/search.rs`.
+3. Convert terminal event construction and serialization, preserving the one-terminal-event invariant.
+4. Add server tests for normal, capped, cancelled, timeout, and error outcomes.
+5. Add a CLI end-to-end test that exercises `monocle server` and `monocle search --remote-url` over a local SSE connection using deterministic input.
+6. Update `src/server/README.md` and `CHANGELOG.md`.
+7. Run `cargo fmt -- --check`, `cargo test --all-features`, and the repository’s applicable clippy command.
+
+## 12. Notes and Caveats
+
+- `source_bytes_compressed` is planned input volume from broker metadata, not a network-transfer meter. It remains the same for a completed and early-cancelled search over the same broker result set.
+- The executor currently reports a filtered `BgpElem` stream. A BGP UPDATE can yield more than one element, so neither `matched_elements` nor existing `SearchSummary.total_messages` is a literal BGP message count.
+- `matching_files` can be large for broad searches. It is bounded only by the number of selected files; a future request may add a server-configured cap and truncation indicator, but this design does not silently truncate it.

--- a/src/bin/commands/search_remote.rs
+++ b/src/bin/commands/search_remote.rs
@@ -73,13 +73,19 @@ pub enum ProgressData {
     Fields(HashMap<String, serde_json::Value>),
 }
 
-/// Summary for `completed` events.
+/// Final SSE result emitted for completed, cancelled, and error events.
 #[derive(Debug, Clone, Deserialize)]
-pub struct SearchSummary {
+pub struct SearchStreamResult {
+    pub exit_reason: String,
+    pub stats: SearchStreamStats,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchStreamStats {
+    pub matched_elements: u64,
     pub total_files: usize,
     pub successful_files: usize,
     pub failed_files: usize,
-    pub total_messages: u64,
     pub duration_secs: f64,
 }
 
@@ -176,14 +182,16 @@ pub async fn run_remote_search(
                     }
                 }
                 "completed" => {
-                    if let Ok(summary) = serde_json::from_str::<SearchSummary>(&data_line) {
+                    if let Ok(result) = serde_json::from_str::<SearchStreamResult>(&data_line) {
+                        let stats = result.stats;
                         eprintln!(
-                            "[completed] {} files ({} ok, {} failed), {} messages in {:.2}s",
-                            summary.total_files,
-                            summary.successful_files,
-                            summary.failed_files,
-                            summary.total_messages,
-                            summary.duration_secs
+                            "[completed:{}] {} files ({} ok, {} failed), {} matched elements in {:.2}s",
+                            result.exit_reason,
+                            stats.total_files,
+                            stats.successful_files,
+                            stats.failed_files,
+                            stats.matched_elements,
+                            stats.duration_secs
                         );
                     }
                     // Flush table output before returning success
@@ -194,7 +202,14 @@ pub async fn run_remote_search(
                     return Ok(());
                 }
                 "cancelled" => {
-                    eprintln!("[cancelled]");
+                    if let Ok(result) = serde_json::from_str::<SearchStreamResult>(&data_line) {
+                        eprintln!(
+                            "[cancelled:{}] {} matched elements",
+                            result.exit_reason, result.stats.matched_elements
+                        );
+                    } else {
+                        eprintln!("[cancelled]");
+                    }
                     // Flush any partial results before returning error
                     if is_table && !buffered_elems.is_empty() {
                         let table = format_elems_table(&buffered_elems, fields, time_format);
@@ -203,7 +218,11 @@ pub async fn run_remote_search(
                     return Err(anyhow::anyhow!("remote search was cancelled"));
                 }
                 "error" => {
-                    eprintln!("[error] {}", data_line);
+                    if let Ok(result) = serde_json::from_str::<SearchStreamResult>(&data_line) {
+                        eprintln!("[error:{}] {}", result.exit_reason, data_line);
+                    } else {
+                        eprintln!("[error] {}", data_line);
+                    }
                     if is_table && !buffered_elems.is_empty() {
                         let table = format_elems_table(&buffered_elems, fields, time_format);
                         println!("{}", table);

--- a/src/lens/search/mod.rs
+++ b/src/lens/search/mod.rs
@@ -185,6 +185,7 @@ pub enum SearchExitReason {
     Cancelled,
     Timeout,
     MaxResultsReached,
+    Failed,
 }
 
 /// Search execution result including both summary and stop reason.
@@ -192,6 +193,10 @@ pub enum SearchExitReason {
 pub struct SearchOutcome {
     pub summary: SearchSummary,
     pub exit_reason: SearchExitReason,
+    /// Broker-advertised compressed bytes for all selected source files.
+    pub source_bytes_compressed: u64,
+    /// True when every selected file supplied an exact byte size.
+    pub source_bytes_exact: bool,
 }
 
 /// A batch of matched elements from a single MRT file.
@@ -513,6 +518,18 @@ impl SearchLens {
 
         let items = self.query_broker(filters)?;
         let total_files = items.len();
+        let source_bytes_exact = items.iter().all(|item| item.exact_size > 0);
+        let source_bytes_compressed = items
+            .iter()
+            .map(|item| {
+                let size = if item.exact_size > 0 {
+                    item.exact_size
+                } else {
+                    item.rough_size
+                };
+                size.max(0) as u64
+            })
+            .sum();
         sink.on_progress(SearchProgress::FilesFound { count: total_files });
 
         if deadline.is_some_and(|dl| Instant::now() >= dl) {
@@ -525,6 +542,8 @@ impl SearchLens {
                     duration_secs: start_time.elapsed().as_secs_f64(),
                 },
                 exit_reason: SearchExitReason::Timeout,
+                source_bytes_compressed,
+                source_bytes_exact,
             });
         }
 
@@ -548,6 +567,8 @@ impl SearchLens {
             return Ok(SearchOutcome {
                 summary,
                 exit_reason: SearchExitReason::Completed,
+                source_bytes_compressed,
+                source_bytes_exact,
             });
         }
 
@@ -636,6 +657,8 @@ impl SearchLens {
         Ok(SearchOutcome {
             summary,
             exit_reason,
+            source_bytes_compressed,
+            source_bytes_exact,
         })
     }
 

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -83,12 +83,18 @@ Streams BGP search results as Server-Sent Events (`text/event-stream`).
 | `started` | `{batch_size, max_results?, timeout_secs?}` | Stream started |
 | `progress` | `SearchProgress` (varies) | Broker query, file start/complete, progress update |
 | `elements` | `{total_so_far, collector, elements[]}` | Batch of BGP elements |
-| `completed` | `SearchSummary` | Terminal: search completed successfully |
-| `cancelled` | (empty) | Terminal: client disconnected |
-| `error` | `ApiErrorResponse` | Terminal: search failed |
+| `completed` | `SearchStreamResult` | Final: search completed or reached `max_results` |
+| `cancelled` | `SearchStreamResult` | Final: client disconnected, with partial stats |
+| `error` | `SearchStreamResult` | Final: search failed or timed out, with partial stats |
 
-**Terminal event invariant:** A stream emits at most one terminal event
-(`completed`, `cancelled`, or `error`). No events follow a terminal event.
+**Final event invariant:** A stream emits at most one final event
+(`completed`, `cancelled`, or `error`). No events follow a final event.
+
+`SearchStreamResult.stats.matched_elements` counts filtered BGP elements emitted
+by the stream, not raw BGP messages. `source_bytes_compressed` is the
+broker-advertised compressed size of selected files; `source_bytes_exact` is
+false when any file required its rough-size fallback. `matching_collectors` and
+`matching_files` list only sources that emitted at least one matched element.
 
 **Cancellation:** Close the HTTP connection to cancel. The server detects the
 drop and stops the search worker via an `Arc<AtomicBool>` flag.

--- a/src/server/search.rs
+++ b/src/server/search.rs
@@ -9,6 +9,7 @@
 //!
 //! See `SSE_SERVICE_OVERHAUL_DESIGN.md` Section 6 for the algorithm.
 
+use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -25,7 +26,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::lens::parse::ParseElemType;
 use crate::lens::search::{
     SearchControl, SearchElementBatch, SearchExecutionOptions, SearchExitReason, SearchFilters,
-    SearchLens, SearchProgress, SearchSink, SearchSummary,
+    SearchLens, SearchOutcome, SearchProgress, SearchSink,
 };
 use crate::server::http::{ApiError, ApiErrorCode, ApiErrorResponse};
 use crate::server::ServerState;
@@ -168,15 +169,87 @@ pub struct ElementsBatch {
     pub elements: Vec<BgpElem>,
 }
 
+/// Final result for a completed, cancelled, timed-out, or failed SSE search.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchStreamResult {
+    pub exit_reason: SearchExitReason,
+    pub stats: SearchStreamStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ApiErrorResponse>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchStreamStats {
+    /// Filtered BGP elements emitted by the stream, not raw BGP messages.
+    pub matched_elements: u64,
+    pub total_files: usize,
+    pub successful_files: usize,
+    pub failed_files: usize,
+    pub source_bytes_compressed: u64,
+    pub source_bytes_exact: bool,
+    pub duration_secs: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_elements_per_sec: Option<f64>,
+    pub matching_collectors: Vec<String>,
+    pub matching_files: Vec<MatchingFile>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MatchingFile {
+    pub collector: String,
+    pub file_url: String,
+}
+
+impl SearchStreamStats {
+    fn empty() -> Self {
+        Self {
+            matched_elements: 0,
+            total_files: 0,
+            successful_files: 0,
+            failed_files: 0,
+            source_bytes_compressed: 0,
+            source_bytes_exact: true,
+            duration_secs: 0.0,
+            matched_elements_per_sec: None,
+            matching_collectors: Vec::new(),
+            matching_files: Vec::new(),
+        }
+    }
+
+    fn from_outcome(outcome: &SearchOutcome, matching_files: Vec<MatchingFile>) -> Self {
+        let duration_secs = outcome.summary.duration_secs;
+        let matched_elements = outcome.summary.total_messages;
+        let matching_collectors = matching_files
+            .iter()
+            .map(|file| file.collector.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        Self {
+            matched_elements,
+            total_files: outcome.summary.total_files,
+            successful_files: outcome.summary.successful_files,
+            failed_files: outcome.summary.failed_files,
+            source_bytes_compressed: outcome.source_bytes_compressed,
+            source_bytes_exact: outcome.source_bytes_exact,
+            duration_secs,
+            matched_elements_per_sec: (duration_secs > 0.0)
+                .then(|| matched_elements as f64 / duration_secs),
+            matching_collectors,
+            matching_files,
+        }
+    }
+}
+
 /// Internal enum representing SSE events. Each variant maps to an SSE `event:`
 /// name; the `data:` field is the variant's payload serialized as JSON.
 enum SearchStreamEvent {
     Started(SearchStarted),
     Progress(SearchProgress),
     Elements(ElementsBatch),
-    Completed(SearchSummary),
-    Cancelled,
-    Error(ApiErrorResponse),
+    Completed(SearchStreamResult),
+    Cancelled(SearchStreamResult),
+    Error(SearchStreamResult),
 }
 
 impl SearchStreamEvent {
@@ -187,7 +260,7 @@ impl SearchStreamEvent {
             SearchStreamEvent::Progress(data) => ("progress", serde_json::to_value(data).ok()?),
             SearchStreamEvent::Elements(data) => ("elements", serde_json::to_value(data).ok()?),
             SearchStreamEvent::Completed(data) => ("completed", serde_json::to_value(data).ok()?),
-            SearchStreamEvent::Cancelled => ("cancelled", serde_json::Value::Null),
+            SearchStreamEvent::Cancelled(data) => ("cancelled", serde_json::to_value(data).ok()?),
             SearchStreamEvent::Error(data) => ("error", serde_json::to_value(data).ok()?),
         };
 
@@ -348,6 +421,7 @@ fn run_search_worker(config: SearchWorkerConfig) {
     );
 
     let sink = Arc::new(SseSearchSink::new(event_tx.clone(), cancel_flag.clone()));
+    let stats_sink = Arc::clone(&sink);
     let options = SearchExecutionOptions {
         concurrency,
         thread_pool: search_pool,
@@ -363,39 +437,55 @@ fn run_search_worker(config: SearchWorkerConfig) {
         Err(e) => {
             let _ = send_event(
                 &event_tx,
-                SearchStreamEvent::Error(ApiErrorResponse::new(
-                    ApiErrorCode::SearchFailed,
-                    e.to_string(),
-                )),
+                SearchStreamEvent::Error(SearchStreamResult {
+                    exit_reason: SearchExitReason::Failed,
+                    stats: SearchStreamStats::empty(),
+                    error: Some(ApiErrorResponse::new(
+                        ApiErrorCode::SearchFailed,
+                        e.to_string(),
+                    )),
+                }),
             );
             return;
         }
     };
 
+    let result = SearchStreamResult {
+        exit_reason: outcome.exit_reason,
+        stats: SearchStreamStats::from_outcome(&outcome, stats_sink.matching_files()),
+        error: None,
+    };
     match outcome.exit_reason {
         SearchExitReason::Cancelled => {
-            let _ = send_event(&event_tx, SearchStreamEvent::Cancelled);
+            let _ = send_event(&event_tx, SearchStreamEvent::Cancelled(result));
         }
         SearchExitReason::Timeout => {
             let _ = send_event(
                 &event_tx,
-                SearchStreamEvent::Error(ApiErrorResponse::new(
-                    ApiErrorCode::SearchFailed,
-                    format!(
-                        "Search timed out after {} seconds",
-                        timeout_secs.unwrap_or(0)
-                    ),
-                )),
+                SearchStreamEvent::Error(SearchStreamResult {
+                    error: Some(ApiErrorResponse::new(
+                        ApiErrorCode::SearchFailed,
+                        format!(
+                            "Search timed out after {} seconds",
+                            timeout_secs.unwrap_or(0)
+                        ),
+                    )),
+                    ..result
+                }),
             );
         }
         SearchExitReason::Completed | SearchExitReason::MaxResultsReached => {
-            let _ = send_event(&event_tx, SearchStreamEvent::Completed(outcome.summary));
+            let _ = send_event(&event_tx, SearchStreamEvent::Completed(result));
+        }
+        SearchExitReason::Failed => {
+            let _ = send_event(&event_tx, SearchStreamEvent::Error(result));
         }
     }
 }
 
 struct SseSearchState {
     total_so_far: u64,
+    matching_files: BTreeSet<MatchingFile>,
 }
 
 struct SseSearchSink {
@@ -407,10 +497,20 @@ struct SseSearchSink {
 impl SseSearchSink {
     fn new(event_tx: mpsc::Sender<SearchStreamEvent>, cancel_flag: Arc<AtomicBool>) -> Self {
         Self {
-            state: Mutex::new(SseSearchState { total_so_far: 0 }),
+            state: Mutex::new(SseSearchState {
+                total_so_far: 0,
+                matching_files: BTreeSet::new(),
+            }),
             event_tx,
             cancel_flag,
         }
+    }
+
+    fn matching_files(&self) -> Vec<MatchingFile> {
+        self.state
+            .lock()
+            .map(|state| state.matching_files.iter().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -438,6 +538,10 @@ impl SearchSink for SseSearchSink {
         };
 
         state.total_so_far += batch.elements.len() as u64;
+        state.matching_files.insert(MatchingFile {
+            collector: batch.collector.clone(),
+            file_url: batch.file_url.clone(),
+        });
         let event = SearchStreamEvent::Elements(ElementsBatch {
             total_so_far: state.total_so_far,
             collector: Some(batch.collector),
@@ -554,7 +658,49 @@ mod tests {
             max_results: Some(1000),
             timeout_secs: None,
         });
-        let sse = event.to_sse();
-        assert!(sse.is_some());
+        assert!(event.to_sse().is_some());
+    }
+
+    #[test]
+    fn test_terminal_stats_include_sorted_matching_sources() {
+        let outcome = SearchOutcome {
+            summary: crate::lens::search::SearchSummary {
+                total_files: 3,
+                successful_files: 3,
+                failed_files: 0,
+                total_messages: 150,
+                duration_secs: 2.0,
+            },
+            exit_reason: SearchExitReason::Completed,
+            source_bytes_compressed: 120,
+            source_bytes_exact: false,
+        };
+        let stats = SearchStreamStats::from_outcome(
+            &outcome,
+            vec![
+                MatchingFile {
+                    collector: "rrc01".to_string(),
+                    file_url: "b".to_string(),
+                },
+                MatchingFile {
+                    collector: "rrc00".to_string(),
+                    file_url: "a".to_string(),
+                },
+            ],
+        );
+        assert_eq!(stats.matched_elements, 150);
+        assert_eq!(stats.matched_elements_per_sec, Some(75.0));
+        assert_eq!(stats.matching_collectors, vec!["rrc00", "rrc01"]);
+        assert!(!stats.source_bytes_exact);
+    }
+
+    #[test]
+    fn test_cancelled_event_has_result_payload() {
+        let event = SearchStreamEvent::Cancelled(SearchStreamResult {
+            exit_reason: SearchExitReason::Cancelled,
+            stats: SearchStreamStats::empty(),
+            error: None,
+        });
+        assert!(event.to_sse().is_some());
     }
 }


### PR DESCRIPTION
## Summary

* Add final SSE result statistics for completed, cancelled, timeout, and error outcomes.
* Report matched elements, source-byte metadata, result rate, and matching source files.
* Update the `monocle search --remote-url` client for the new final-result payload.

## Validation

* `cargo fmt -- --check`
* `cargo test --all-features`
* `cargo clippy --lib --all-features -- -D warnings`
* Manual `monocle server` → `monocle search --remote-url` SSE check

Fixes #135
