### PR TITLE
feat(rpki): add RPKISPOOL historical source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+* Added RPKISPOOL as the default historical RPKI source with Sobornost as the
+  default mirror. The `rpki roas` and `rpki aspas` commands retain `ripe` and
+  `rpkiviews`; invalid source/collector combinations now return errors (#134).
 * Added `--use-cache` / `--cache-dir` MRT-file caching and `--fields` output
   selection to the `rib` command (#137).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ All notable changes to this project will be documented in this file.
 
 ### Code Improvements
 
+* Removed redundant formatting references in `parse` command output to satisfy
+  current Clippy checks.
 * Made refresh index rebuilds atomic by wrapping index drops, table clears,
   inserts, and index recreation in one transaction; indexes are dropped before
   clearing tables to avoid unnecessary per-row index maintenance during refresh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ All notable changes to this project will be documented in this file.
 
 ### Code Improvements
 
+* Added `HistoricalRpkiCollectorOption` as the preferred general-purpose alias
+  while retaining `RpkiViewsCollectorOption` compatibility, and clarified
+  historical source/collector CLI errors.
 * Removed redundant formatting references in `parse` command output to satisfy
   current Clippy checks.
 * Made refresh index rebuilds atomic by wrapping index drops, table clears,

--- a/src/bin/commands/parse.rs
+++ b/src/bin/commands/parse.rs
@@ -155,7 +155,7 @@ pub fn run(args: ParseArgs, output_format: OutputFormat) {
                 } else {
                     // Print header for markdown format
                     if let Some(header) = get_header(output_format, &fields) {
-                        if let Err(e) = writeln!(stdout, "{}", &header) {
+                        if let Err(e) = writeln!(stdout, "{}", header) {
                             if e.kind() != std::io::ErrorKind::BrokenPipe {
                                 eprintln!("ERROR: {e}");
                             }
@@ -172,7 +172,7 @@ pub fn run(args: ParseArgs, output_format: OutputFormat) {
                             collector.as_deref(),
                             time_format,
                         ) {
-                            if let Err(e) = writeln!(stdout, "{}", &output_str) {
+                            if let Err(e) = writeln!(stdout, "{}", output_str) {
                                 if e.kind() != std::io::ErrorKind::BrokenPipe {
                                     eprintln!("ERROR: {e}");
                                 }
@@ -187,7 +187,7 @@ pub fn run(args: ParseArgs, output_format: OutputFormat) {
             // Streaming output (no buffering needed)
             // Print header for markdown format before first element
             if let Some(header) = get_header(output_format, &fields) {
-                if let Err(e) = writeln!(stdout, "{}", &header) {
+                if let Err(e) = writeln!(stdout, "{}", header) {
                     if e.kind() != std::io::ErrorKind::BrokenPipe {
                         eprintln!("ERROR: {e}");
                     }
@@ -200,7 +200,7 @@ pub fn run(args: ParseArgs, output_format: OutputFormat) {
                 if let Some(output_str) =
                     format_elem(&elem, output_format, &fields, None, time_format)
                 {
-                    if let Err(e) = writeln!(stdout, "{}", &output_str) {
+                    if let Err(e) = writeln!(stdout, "{}", output_str) {
                         if e.kind() != std::io::ErrorKind::BrokenPipe {
                             eprintln!("ERROR: {e}");
                         }
@@ -217,7 +217,7 @@ pub fn run(args: ParseArgs, output_format: OutputFormat) {
                     std::process::exit(1);
                 }
             };
-            eprintln!("processing. filtered messages output to {}...", &path);
+            eprintln!("processing. filtered messages output to {}...", path);
             let mut encoder = MrtUpdatesEncoder::new();
             let mut writer = match oneio::get_writer(&path) {
                 Ok(w) => w,

--- a/src/bin/commands/rpki.rs
+++ b/src/bin/commands/rpki.rs
@@ -36,13 +36,13 @@ pub enum RpkiCommands {
         #[clap(long)]
         date: Option<String>,
 
-        /// Historical data source: ripe, rpkiviews (default: ripe)
-        #[clap(long, default_value = "ripe")]
+        /// Historical data source: rpkispools, ripe, rpkiviews (default: rpkispools)
+        #[clap(long, default_value = "rpkispools")]
         source: String,
 
-        /// RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost)
-        #[clap(long, default_value = "sobornost")]
-        collector: String,
+        /// Historical collector: sobornost, attn, kerfuffle (massars is only available with rpkiviews; default for mirrors: sobornost)
+        #[clap(long)]
+        collector: Option<String>,
 
         /// Force refresh the RPKI cache (only applies to current data)
         #[clap(long, short)]
@@ -63,13 +63,13 @@ pub enum RpkiCommands {
         #[clap(long)]
         date: Option<String>,
 
-        /// Historical data source: ripe, rpkiviews (default: ripe)
-        #[clap(long, default_value = "ripe")]
+        /// Historical data source: rpkispools, ripe, rpkiviews (default: rpkispools)
+        #[clap(long, default_value = "rpkispools")]
         source: String,
 
-        /// RPKIviews collector: sobornost, massars, attn, kerfuffle (default: sobornost)
-        #[clap(long, default_value = "sobornost")]
-        collector: String,
+        /// Historical collector: sobornost, attn, kerfuffle (massars is only available with rpkiviews; default for mirrors: sobornost)
+        #[clap(long)]
+        collector: Option<String>,
 
         /// Force refresh the RPKI cache (only applies to current data)
         #[clap(long, short)]
@@ -415,21 +415,47 @@ fn run_validate(
     }
 }
 
-fn parse_data_source(source: &str) -> RpkiDataSource {
+fn parse_data_source(source: &str) -> Result<RpkiDataSource, String> {
     match source.to_lowercase().as_str() {
-        "ripe" => RpkiDataSource::Ripe,
-        "rpkiviews" => RpkiDataSource::RpkiViews,
-        _ => RpkiDataSource::Cloudflare,
+        "ripe" => Ok(RpkiDataSource::Ripe),
+        "rpkiviews" => Ok(RpkiDataSource::RpkiViews),
+        "rpkispools" => Ok(RpkiDataSource::RpkiSpools),
+        _ => Err(format!(
+            "Unknown historical RPKI source '{}'. Valid options: rpkispools, ripe, rpkiviews",
+            source
+        )),
     }
 }
 
-fn parse_collector(collector: &str) -> Option<RpkiViewsCollectorOption> {
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rpkispools_data_source() {
+        assert!(matches!(
+            parse_data_source("rpkispools").unwrap(),
+            RpkiDataSource::RpkiSpools
+        ));
+    }
+
+    #[test]
+    fn test_reject_unknown_historical_source_and_collector() {
+        assert!(parse_data_source("unknown").is_err());
+        assert!(parse_collector("unknown").is_err());
+    }
+}
+
+fn parse_collector(collector: &str) -> Result<RpkiViewsCollectorOption, String> {
     match collector.to_lowercase().as_str() {
-        "sobornost" => Some(RpkiViewsCollectorOption::Sobornost),
-        "massars" => Some(RpkiViewsCollectorOption::Massars),
-        "attn" => Some(RpkiViewsCollectorOption::Attn),
-        "kerfuffle" => Some(RpkiViewsCollectorOption::Kerfuffle),
-        _ => None,
+        "sobornost" => Ok(RpkiViewsCollectorOption::Sobornost),
+        "massars" => Ok(RpkiViewsCollectorOption::Massars),
+        "attn" => Ok(RpkiViewsCollectorOption::Attn),
+        "kerfuffle" => Ok(RpkiViewsCollectorOption::Kerfuffle),
+        _ => Err(format!(
+            "Unknown historical RPKI collector '{}'. Valid options: sobornost, attn, kerfuffle; massars is only available with rpkiviews",
+            collector
+        )),
     }
 }
 
@@ -438,7 +464,7 @@ fn run_roas(
     resources: Vec<String>,
     date: Option<String>,
     source: String,
-    collector: String,
+    collector: Option<String>,
     refresh: bool,
     output_format: OutputFormat,
     config: &MonocleConfig,
@@ -456,6 +482,21 @@ fn run_roas(
         None => {
             // For current data (no date), use SQLite cache
             run_roas_from_cache(resources, refresh, output_format, config, no_update);
+            return;
+        }
+    };
+
+    let data_source = match parse_data_source(&source) {
+        Ok(data_source) => data_source,
+        Err(error) => {
+            eprintln!("ERROR: {}", error);
+            return;
+        }
+    };
+    let collector_option = match collector.as_deref().map(parse_collector).transpose() {
+        Ok(collector) => collector,
+        Err(error) => {
+            eprintln!("ERROR: {}", error);
             return;
         }
     };
@@ -499,15 +540,11 @@ fn run_roas(
     if asns.is_empty() && prefixes.is_empty() {
         let args = RpkiRoaLookupArgs::new()
             .with_date(parsed_date)
-            .with_source(parse_data_source(&source));
+            .with_source(data_source.clone());
 
-        let args = if let Some(c) = parse_collector(&collector) {
-            RpkiRoaLookupArgs {
-                collector: Some(c),
-                ..args
-            }
-        } else {
-            args
+        let args = RpkiRoaLookupArgs {
+            collector: collector_option.clone(),
+            ..args
         };
 
         let roas = match lens.get_roas(&args) {
@@ -531,15 +568,11 @@ fn run_roas(
         let args = RpkiRoaLookupArgs::new()
             .with_asn(*asn)
             .with_date(parsed_date)
-            .with_source(parse_data_source(&source));
+            .with_source(data_source.clone());
 
-        let args = if let Some(c) = parse_collector(&collector) {
-            RpkiRoaLookupArgs {
-                collector: Some(c),
-                ..args
-            }
-        } else {
-            args
+        let args = RpkiRoaLookupArgs {
+            collector: collector_option.clone(),
+            ..args
         };
 
         match lens.get_roas(&args) {
@@ -562,15 +595,11 @@ fn run_roas(
         let args = RpkiRoaLookupArgs::new()
             .with_prefix(prefix)
             .with_date(parsed_date)
-            .with_source(parse_data_source(&source));
+            .with_source(data_source.clone());
 
-        let args = if let Some(c) = parse_collector(&collector) {
-            RpkiRoaLookupArgs {
-                collector: Some(c),
-                ..args
-            }
-        } else {
-            args
+        let args = RpkiRoaLookupArgs {
+            collector: collector_option.clone(),
+            ..args
         };
 
         match lens.get_roas(&args) {
@@ -845,7 +874,7 @@ fn run_aspas(
     provider: Option<u32>,
     date: Option<String>,
     source: String,
-    collector: String,
+    collector: Option<String>,
     refresh: bool,
     output_format: OutputFormat,
     config: &MonocleConfig,
@@ -870,6 +899,21 @@ fn run_aspas(
                 config,
                 no_update,
             );
+            return;
+        }
+    };
+
+    let data_source = match parse_data_source(&source) {
+        Ok(data_source) => data_source,
+        Err(error) => {
+            eprintln!("ERROR: {}", error);
+            return;
+        }
+    };
+    let collector_option = match collector.as_deref().map(parse_collector).transpose() {
+        Ok(collector) => collector,
+        Err(error) => {
+            eprintln!("ERROR: {}", error);
             return;
         }
     };
@@ -905,8 +949,8 @@ fn run_aspas(
     // Set date and source
     args = RpkiAspaLookupArgs {
         date: Some(parsed_date),
-        source: parse_data_source(&source),
-        collector: parse_collector(&collector),
+        source: data_source,
+        collector: collector_option,
         ..args
     };
 

--- a/src/bin/commands/rpki.rs
+++ b/src/bin/commands/rpki.rs
@@ -3,8 +3,8 @@ use clap::Subcommand;
 use monocle::database::{MonocleDatabase, RpkiRoaRecord};
 use monocle::lens::rpki::commons::parse_historical_source;
 use monocle::lens::rpki::{
-    RpkiAspaLookupArgs, RpkiAspaTableEntry, RpkiDataSource, RpkiLens, RpkiRoaEntry,
-    RpkiRoaLookupArgs, RpkiViewsCollectorOption,
+    HistoricalRpkiCollectorOption, RpkiAspaLookupArgs, RpkiAspaTableEntry, RpkiDataSource,
+    RpkiLens, RpkiRoaEntry, RpkiRoaLookupArgs,
 };
 use monocle::utils::OutputFormat;
 use monocle::MonocleConfig;
@@ -421,6 +421,10 @@ fn parse_data_source(source: &str) -> Result<RpkiDataSource, String> {
         "ripe" => Ok(RpkiDataSource::Ripe),
         "rpkiviews" => Ok(RpkiDataSource::RpkiViews),
         "rpkispools" => Ok(RpkiDataSource::RpkiSpools),
+        "cloudflare" => Err(
+            "Cloudflare only supports current (undated) RPKI data; omit --date to use it"
+                .to_string(),
+        ),
         _ => Err(format!(
             "Unknown historical RPKI source '{}'. Valid options: rpkispools, ripe, rpkiviews",
             source
@@ -435,9 +439,27 @@ mod tests {
     #[test]
     fn test_parse_rpkispools_data_source() {
         assert!(matches!(
-            parse_data_source("rpkispools").unwrap(),
-            RpkiDataSource::RpkiSpools
+            parse_data_source("rpkispools"),
+            Ok(RpkiDataSource::RpkiSpools)
         ));
+    }
+
+    #[test]
+    fn test_parse_data_source_explains_cloudflare_is_current_only() {
+        let error = match parse_data_source("cloudflare") {
+            Err(error) => error,
+            Ok(_) => panic!("cloudflare is not historical"),
+        };
+        assert!(error.contains("current (undated) RPKI data"));
+    }
+
+    #[test]
+    fn test_parse_collector_lists_rpkiviews_only_massars() {
+        let error = match parse_collector("unknown") {
+            Err(error) => error,
+            Ok(_) => panic!("collector should be rejected"),
+        };
+        assert!(error.contains("massars"));
     }
 
     #[test]
@@ -447,14 +469,14 @@ mod tests {
     }
 }
 
-fn parse_collector(collector: &str) -> Result<RpkiViewsCollectorOption, String> {
+fn parse_collector(collector: &str) -> Result<HistoricalRpkiCollectorOption, String> {
     match collector.to_lowercase().as_str() {
-        "sobornost" => Ok(RpkiViewsCollectorOption::Sobornost),
-        "massars" => Ok(RpkiViewsCollectorOption::Massars),
-        "attn" => Ok(RpkiViewsCollectorOption::Attn),
-        "kerfuffle" => Ok(RpkiViewsCollectorOption::Kerfuffle),
+        "sobornost" => Ok(HistoricalRpkiCollectorOption::Sobornost),
+        "massars" => Ok(HistoricalRpkiCollectorOption::Massars),
+        "attn" => Ok(HistoricalRpkiCollectorOption::Attn),
+        "kerfuffle" => Ok(HistoricalRpkiCollectorOption::Kerfuffle),
         _ => Err(format!(
-            "Unknown historical RPKI collector '{}'. Valid options: sobornost, attn, kerfuffle; massars is only available with rpkiviews",
+            "Unknown historical RPKI collector '{}'. Valid options: sobornost, attn, kerfuffle, massars (massars is only available with rpkiviews)",
             collector
         )),
     }

--- a/src/bin/commands/rpki.rs
+++ b/src/bin/commands/rpki.rs
@@ -1,6 +1,7 @@
 use chrono::NaiveDate;
 use clap::Subcommand;
 use monocle::database::{MonocleDatabase, RpkiRoaRecord};
+use monocle::lens::rpki::commons::parse_historical_source;
 use monocle::lens::rpki::{
     RpkiAspaLookupArgs, RpkiAspaTableEntry, RpkiDataSource, RpkiLens, RpkiRoaEntry,
     RpkiRoaLookupArgs, RpkiViewsCollectorOption,
@@ -490,16 +491,21 @@ fn run_roas(
         Ok(data_source) => data_source,
         Err(error) => {
             eprintln!("ERROR: {}", error);
-            return;
+            std::process::exit(1);
         }
     };
     let collector_option = match collector.as_deref().map(parse_collector).transpose() {
         Ok(collector) => collector,
         Err(error) => {
             eprintln!("ERROR: {}", error);
-            return;
+            std::process::exit(1);
         }
     };
+
+    if let Err(error) = parse_historical_source(&source, collector.as_deref()) {
+        eprintln!("ERROR: {}", error);
+        std::process::exit(1);
+    }
 
     // For historical data, use the lens directly
     // Display data source
@@ -907,16 +913,21 @@ fn run_aspas(
         Ok(data_source) => data_source,
         Err(error) => {
             eprintln!("ERROR: {}", error);
-            return;
+            std::process::exit(1);
         }
     };
     let collector_option = match collector.as_deref().map(parse_collector).transpose() {
         Ok(collector) => collector,
         Err(error) => {
             eprintln!("ERROR: {}", error);
-            return;
+            std::process::exit(1);
         }
     };
+
+    if let Err(error) = parse_historical_source(&source, collector.as_deref()) {
+        eprintln!("ERROR: {}", error);
+        std::process::exit(1);
+    }
 
     // For historical data, use the lens directly
     // Display data source

--- a/src/lens/rpki/commons.rs
+++ b/src/lens/rpki/commons.rs
@@ -290,12 +290,12 @@ mod tests {
     #[test]
     fn test_parse_rpkiviews_collector() {
         assert!(matches!(
-            parse_rpkiviews_collector("sobornost").unwrap(),
-            RpkiViewsCollector::SobornostNet
+            parse_rpkiviews_collector("sobornost"),
+            Ok(RpkiViewsCollector::SobornostNet)
         ));
         assert!(matches!(
-            parse_rpkiviews_collector("kerfuffle").unwrap(),
-            RpkiViewsCollector::KerfuffleNet
+            parse_rpkiviews_collector("kerfuffle"),
+            Ok(RpkiViewsCollector::KerfuffleNet)
         ));
         assert!(parse_rpkiviews_collector("invalid").is_err());
     }
@@ -303,17 +303,21 @@ mod tests {
     #[test]
     fn test_parse_historical_source() {
         assert!(matches!(
-            parse_historical_source("ripe", None).unwrap(),
-            HistoricalRpkiSource::Ripe
+            parse_historical_source("ripe", None),
+            Ok(HistoricalRpkiSource::Ripe)
         ));
         assert!(parse_historical_source("ripe", Some("sobornost")).is_err());
         assert!(matches!(
-            parse_historical_source("rpkiviews", Some("sobornost")).unwrap(),
-            HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::SobornostNet)
+            parse_historical_source("rpkiviews", Some("sobornost")),
+            Ok(HistoricalRpkiSource::RpkiViews(
+                RpkiViewsCollector::SobornostNet
+            ))
         ));
         assert!(matches!(
-            parse_historical_source("rpkiviews", Some("massars")).unwrap(),
-            HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::MassarsNet)
+            parse_historical_source("rpkiviews", Some("massars")),
+            Ok(HistoricalRpkiSource::RpkiViews(
+                RpkiViewsCollector::MassarsNet
+            ))
         ));
     }
 

--- a/src/lens/rpki/commons.rs
+++ b/src/lens/rpki/commons.rs
@@ -2,11 +2,13 @@
 //!
 //! This module provides functions to load and query RPKI data (ROAs and ASPAs)
 //! from bgpkit-commons, supporting both current (Cloudflare) and historical
-//! (RIPE NCC, RPKIviews) data sources.
+//! (RIPE NCC, RPKIviews, and RPKISPOOL) data sources.
 
 use crate::utils::truncate_name;
 use anyhow::{anyhow, Result};
-use bgpkit_commons::rpki::{HistoricalRpkiSource, RpkiTrie, RpkiViewsCollector};
+use bgpkit_commons::rpki::{
+    HistoricalRpkiSource, RpkiSpoolsCollector, RpkiTrie, RpkiViewsCollector,
+};
 use chrono::NaiveDate;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
@@ -91,20 +93,46 @@ pub fn parse_rpkiviews_collector(collector: &str) -> Result<RpkiViewsCollector> 
     }
 }
 
+/// Parse RPKISPOOL collector from string
+pub fn parse_rpkispools_collector(collector: &str) -> Result<RpkiSpoolsCollector> {
+    match collector.to_lowercase().as_str() {
+        "sobornost" | "sobornostnet" => Ok(RpkiSpoolsCollector::SobornostNet),
+        "attn" | "attnjp" => Ok(RpkiSpoolsCollector::AttnJp),
+        "kerfuffle" | "kerfufflenet" => Ok(RpkiSpoolsCollector::KerfuffleNet),
+        _ => Err(anyhow!(
+            "Unknown RPKISPOOL collector: {}. Valid options: sobornost, attn, kerfuffle",
+            collector
+        )),
+    }
+}
+
 /// Parse historical RPKI source from strings
 pub fn parse_historical_source(
     source: &str,
     collector: Option<&str>,
 ) -> Result<HistoricalRpkiSource> {
     match source.to_lowercase().as_str() {
-        "ripe" => Ok(HistoricalRpkiSource::Ripe),
+        "ripe" => {
+            if let Some(collector) = collector {
+                return Err(anyhow!(
+                    "Collector '{}' is not supported with the RIPE historical RPKI source",
+                    collector
+                ));
+            }
+            Ok(HistoricalRpkiSource::Ripe)
+        }
         "rpkiviews" => {
             let collector = collector.unwrap_or("sobornost");
             let rpkiviews_collector = parse_rpkiviews_collector(collector)?;
             Ok(HistoricalRpkiSource::RpkiViews(rpkiviews_collector))
         }
+        "rpkispools" => {
+            let collector = collector.unwrap_or("sobornost");
+            let rpkispools_collector = parse_rpkispools_collector(collector)?;
+            Ok(HistoricalRpkiSource::RpkiSpools(rpkispools_collector))
+        }
         _ => Err(anyhow!(
-            "Unknown RPKI source: {}. Valid options: ripe, rpkiviews",
+            "Unknown RPKI source: {}. Valid options: ripe, rpkiviews, rpkispools",
             source
         )),
     }
@@ -136,7 +164,7 @@ pub fn load_rpki_data(
     match date {
         None => load_current_rpki(),
         Some(d) => {
-            let source_str = source.unwrap_or("ripe");
+            let source_str = source.unwrap_or("rpkispools");
             let historical_source = parse_historical_source(source_str, collector)?;
             load_historical_rpki(d, historical_source)
         }
@@ -278,9 +306,22 @@ mod tests {
             parse_historical_source("ripe", None).unwrap(),
             HistoricalRpkiSource::Ripe
         ));
+        assert!(parse_historical_source("ripe", Some("sobornost")).is_err());
         assert!(matches!(
             parse_historical_source("rpkiviews", Some("sobornost")).unwrap(),
             HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::SobornostNet)
         ));
+        assert!(matches!(
+            parse_historical_source("rpkiviews", Some("massars")).unwrap(),
+            HistoricalRpkiSource::RpkiViews(RpkiViewsCollector::MassarsNet)
+        ));
+    }
+
+    #[test]
+    fn test_parse_rpkispools_historical_source() {
+        assert!(parse_historical_source("rpkispools", Some("sobornost")).is_ok());
+        assert!(parse_historical_source("rpkispools", Some("attn")).is_ok());
+        assert!(parse_historical_source("rpkispools", Some("kerfuffle")).is_ok());
+        assert!(parse_historical_source("rpkispools", Some("massars")).is_err());
     }
 }

--- a/src/lens/rpki/mod.rs
+++ b/src/lens/rpki/mod.rs
@@ -58,7 +58,11 @@ pub enum RpkiDataSource {
     RpkiSpools,
 }
 
-/// Historical collector options
+/// RPKIViews collector options.
+///
+/// Kept as the compatibility name for the original public API. New APIs should
+/// use [`HistoricalRpkiCollectorOption`] because Sobornost, ATTN, and Kerfuffle
+/// are also available from RPKISPOOL.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum RpkiViewsCollectorOption {
@@ -72,6 +76,12 @@ pub enum RpkiViewsCollectorOption {
     /// KerfuffleNet collector
     Kerfuffle,
 }
+
+/// Collector options shared by historical RPKI data sources.
+///
+/// This is the preferred name for new code. [`RpkiViewsCollectorOption`] remains
+/// available for backwards compatibility.
+pub type HistoricalRpkiCollectorOption = RpkiViewsCollectorOption;
 
 /// Validation state for RPKI route origin validation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -172,10 +182,10 @@ pub struct RpkiRoaLookupArgs {
     #[serde(default)]
     pub source: RpkiDataSource,
 
-    /// RPKIviews collector (only used with rpkiviews source)
+    /// Historical collector (RPKIViews or RPKISPOOL, depending on source)
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(default)]
-    pub collector: Option<RpkiViewsCollectorOption>,
+    pub collector: Option<HistoricalRpkiCollectorOption>,
 
     /// Output format
     #[cfg_attr(feature = "cli", clap(short, long, default_value = "table"))]
@@ -249,10 +259,10 @@ pub struct RpkiAspaLookupArgs {
     #[serde(default)]
     pub source: RpkiDataSource,
 
-    /// RPKIviews collector (only used with rpkiviews source)
+    /// Historical collector (RPKIViews or RPKISPOOL, depending on source)
     #[cfg_attr(feature = "cli", clap(long))]
     #[serde(default)]
-    pub collector: Option<RpkiViewsCollectorOption>,
+    pub collector: Option<HistoricalRpkiCollectorOption>,
 
     /// Output format
     #[cfg_attr(feature = "cli", clap(short, long, default_value = "table"))]

--- a/src/lens/rpki/mod.rs
+++ b/src/lens/rpki/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides RPKI-related functionality including:
 //! - ROA (Route Origin Authorization) lookup and validation
 //! - ASPA (Autonomous System Provider Authorization) data access
-//! - Historical RPKI data support via RIPE NCC and RPKIviews
+//! - Historical RPKI data support via RIPE NCC, RPKIviews, and RPKISPOOL
 //! - RTR (RPKI-to-Router) protocol support for fetching ROAs
 //!
 //! The lens uses `RpkiRepository` for cached/current data operations,
@@ -54,9 +54,11 @@ pub enum RpkiDataSource {
     Ripe,
     /// Historical data from RPKIviews
     RpkiViews,
+    /// Historical data from RPKISPOOL
+    RpkiSpools,
 }
 
-/// RPKIviews collector options
+/// Historical collector options
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum RpkiViewsCollectorOption {
@@ -334,7 +336,7 @@ impl RpkiValidateArgs {
 ///    first via `refresh()`.
 ///
 /// 2. **Historical data operations**: When a date is specified in lookup args,
-///    loads data directly from bgpkit-commons (RIPE NCC or RPKIviews).
+///    loads data directly from bgpkit-commons (RIPE NCC, RPKIviews, or RPKISPOOL).
 ///
 /// # Example
 ///
@@ -811,6 +813,7 @@ impl<'a> RpkiLens<'a> {
             RpkiDataSource::Cloudflare => None,
             RpkiDataSource::Ripe => Some("ripe"),
             RpkiDataSource::RpkiViews => Some("rpkiviews"),
+            RpkiDataSource::RpkiSpools => Some("rpkispools"),
         };
 
         let collector_str = collector.map(|c| match c {

--- a/tests/rpki_cli.rs
+++ b/tests/rpki_cli.rs
@@ -1,0 +1,60 @@
+use std::process::Command;
+
+fn assert_invalid_historical_selection(args: &[&str], expected_error: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_monocle"))
+        .args(args)
+        .output()
+        .expect("monocle CLI should run");
+
+    assert!(
+        !output.status.success(),
+        "expected a nonzero exit status; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected_error),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn rejects_invalid_historical_rpki_selections() {
+    assert_invalid_historical_selection(
+        &[
+            "rpki",
+            "aspas",
+            "--date",
+            "2026-06-28",
+            "--source",
+            "unknown",
+        ],
+        "Unknown historical RPKI source",
+    );
+    assert_invalid_historical_selection(
+        &[
+            "rpki",
+            "aspas",
+            "--date",
+            "2026-06-28",
+            "--source",
+            "ripe",
+            "--collector",
+            "sobornost",
+        ],
+        "not supported with the RIPE historical RPKI source",
+    );
+    assert_invalid_historical_selection(
+        &[
+            "rpki",
+            "aspas",
+            "--date",
+            "2026-06-28",
+            "--source",
+            "rpkispools",
+            "--collector",
+            "massars",
+        ],
+        "Unknown RPKISPOOL collector",
+    );
+}


### PR DESCRIPTION
## Summary
- Add RPKISPOOL historical ROA and ASPA loading via bgpkit-commons.
- Make `rpkispools` with the Sobornost mirror the default for dated CLI queries.
- Retain RIPE and RPKIViews options, including RPKIViews-only Massars.
- Reject invalid historical sources and source/collector combinations with a nonzero exit status.
- Update existing parse output formatting for current Clippy compatibility.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features` — 272 passed, 1 ignored; 13 CLI unit tests; 1 CLI integration test; 9 doc tests passed.
- Live `rpki aspas --date 2026-06-28 --format json`: 2,208 ASPA records from RPKISPOOL/Sobornost in 17 seconds.
- Live RPKISPOOL/ATTN verification: 2,208 ASPA records in 19 seconds.

Closes #134