### PR TITLE
ci: native per-platform Docker builds with cargo-chef and registry cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
       - "src/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".dockerignore"
       - ".github/workflows/docker.yml"
     # On new version tag → tag as bgpkit/monocle:{version} and bgpkit/monocle:latest
     tags:
@@ -20,8 +21,18 @@ permissions:
   contents: read
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,22 +56,77 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # QEMU enables building for non-native architectures (e.g. arm64 on
-      # amd64 runners) via emulation. Slower than native runners but works
-      # for a single-job workflow without splitting into a platform matrix.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=bgpkit/monocle,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=bgpkit/monocle:buildcache-${{ matrix.architecture }}
+          cache-to: type=registry,ref=bgpkit/monocle:buildcache-${{ matrix.architecture }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: bgpkit/monocle
+          # On branch push to main: type=ref,event=branch → "main"
+          # On tag push v1.3.0: type=semver → "1.3.0", "1.3", and "latest"
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          args=()
+          while IFS= read -r tag; do
+            args+=(--tag "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          for digest in *; do
+            args+=("bgpkit/monocle@sha256:$digest")
+          done
+          docker buildx imagetools create "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,20 @@ All notable changes to this project will be documented in this file.
 * `GET /api/v1/rpki/roa/lookup` now applies AND semantics when both `prefix`
   and `asn` are provided (filters covering ROAs by origin ASN).
 
+### Build & Infrastructure
+
+* Replaced QEMU-emulated multi-platform Docker build with native per-platform
+  builds: `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`
+  native runners. Each build pushes by digest; a final manifest-merge job
+  assembles the multi-architecture OCI image index. Expected to reduce CI build
+  time from ~57 minutes to roughly the slower platform's native compile time.
+* Added `cargo-chef` to the Dockerfile for dependency-layer caching. Source-only
+  changes now reuse the pre-compiled dependency layer instead of recompiling all
+  dependencies from scratch.
+* Switched Docker BuildKit cache from GitHub Actions cache to registry-based
+  cache (`bgpkit/monocle:buildcache-{arch}`), removing the 10 GB GHA cache
+  budget constraint.
+
 ### Code Improvements
 
 * Added `HistoricalRpkiCollectorOption` as the preferred general-purpose alias

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,44 @@
-FROM rust:1-bookworm AS builder
+# syntax=docker/dockerfile:1
+FROM rust:1-bookworm AS chef
 WORKDIR /app
-COPY . .
-RUN cargo build --release --features cli --bin monocle
+RUN cargo install cargo-chef --locked
 
+# ------------------------------------------------------------------------------
+# Planner: extract dependency recipe from Cargo.toml + Cargo.lock + source
+# structure (crate names, binary/example/example targets). Does NOT compile.
+# Invalidated on source changes, but runs in seconds.
+# ------------------------------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ------------------------------------------------------------------------------
+# Builder: compile dependencies from recipe, then the real application source.
+# The dependency-cook layer is only invalidated when the dependency tree changes
+# (Cargo.toml/Cargo.lock), NOT on routine source edits.
+# ------------------------------------------------------------------------------
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo chef cook --release --features cli --bin monocle --recipe-path recipe.json
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --features cli --bin monocle && \
+    cp /app/target/release/monocle /usr/local/bin/monocle
+
+# ------------------------------------------------------------------------------
+# Runtime image
+# ------------------------------------------------------------------------------
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app/target/release/monocle /usr/local/bin/monocle
+COPY --from=builder /usr/local/bin/monocle /usr/local/bin/monocle
 
 # Run as a non-root user for security
 RUN groupadd --system monocle && useradd --system --gid monocle --no-create-home --shell /usr/sbin/nologin monocle
 RUN mkdir -p /data/monocle /cache/monocle /home/monocle/.config/monocle \
     && chown -R monocle:monocle /data/monocle /cache/monocle /home/monocle
+
 USER monocle
 
 # Default config: bind to all interfaces, port 8080


### PR DESCRIPTION
## Summary

- Replaced QEMU-emulated multi-platform Docker build with native per-platform builds on AMD64 and ARM64 runners
- Added `cargo-chef` to Dockerfile for dependency-layer caching
- Switched BuildKit cache from GHA to registry-based cache

## Changes

### `.github/workflows/docker.yml`
- Split single QEMU job into a two-entry matrix:
  - `linux/amd64` on `ubuntu-latest`
  - `linux/arm64` on `ubuntu-24.04-arm` (native ARM runner)
- Each build pushes an untagged image by digest
- Added `merge` job that assembles a multi-architecture OCI image index via `docker buildx imagetools create`
- Per-platform registry cache (`bgpkit/monocle:buildcache-{arch}`)

### `Dockerfile`
- Three-stage cargo-chef pattern: `chef` → `planner` → `builder`
- Dependencies compiled from recipe (`cargo chef cook`) in a cacheable layer separate from application source
- `RUN --mount=type=cache` for Cargo registry

### `CHANGELOG.md`
- Added Build &amp; Infrastructure section

## Expected impact

| Metric | Before | After (expected) |
|---|---|---|
| ARM64 build | ~54 min (QEMU emulation) | native compile time |
| Source-only changes | Full dependency recompile | Only application crate recompiled |
| Cache budget | 10 GB GHA limit | Unlimited (registry) |

## Verification

- Local Docker build succeeded; binary reports `monocle 1.3.0`
- `actionlint` passes
- `docker buildx build --check` passes (no warnings)
- Repeated local build confirmed all layers cached